### PR TITLE
Fix scaleTargetRef name

### DIFF
--- a/helm-chart-sources/logstream-workergroup/templates/hpa.yaml
+++ b/helm-chart-sources/logstream-workergroup/templates/hpa.yaml
@@ -9,7 +9,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "logstream-workergroup.fullname" . }}-{{ .Values.config.tag }}
+    name: {{ include "logstream-workergroup.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:


### PR DESCRIPTION
Remove tag from scaleTargetRef name as it refers to non-existent deployment name.