### PR TITLE
Fix issue with override warning.

### DIFF
--- a/helm-chart-sources/logstream-master/values.yaml
+++ b/helm-chart-sources/logstream-master/values.yaml
@@ -26,7 +26,7 @@ config:
   criblHome: /opt/cribl
   rejectSelfSignedCerts: 0
   healthPort: 9000
-  groups: {}
+  groups: []
   
 env: {}
 


### PR DESCRIPTION
Fixing issue: `coalesce.go:200: warning: cannot overwrite table with non table for groups (map[])`

Fixes #6