### PR TITLE
Change master service `internalType` from `LoadBalancer` to `ClusterIP`

### DIFF
--- a/helm-chart-sources/logstream-master/README.md
+++ b/helm-chart-sources/logstream-master/README.md
@@ -49,6 +49,7 @@ This section covers the most likely values to override. To see the full scope of
 |config.rejectSelfSignedCerts|Number|0|0 - allow self-signed certs, 1 - deny self-signed certs|
 |config.healthPort|number|9000|the port to use for health checks (readiness/live)|
 |service.ports|Array of Maps|<pre>- name: api<br>  port: 9000<br>  protocol: TCP<br>  external: true<br>- name: mastercomm<br>  port: 4200<br>  protocol: TCP<br>  external: false</pre>|The ports to make available both in the Deployment and the Service. Each "map" in the list needs the following values set: <dl><dt>containerPort</dt><dd>the port to be made available</dd><dt>name</dt><dd>a descriptive name of what the port is being used for</dd><dt>protocol</dt><dd>the protocol in use for this port (UDP/TCP)</dd><dt>external</dt><dd>Set to true to be exposed on the external service, or false not to</dd></dl>|
+|service.internalType|String|ClusterIP|Change this setting to `LoadBalancer` to expose port 4200 externally. By default, worker to master communications on port 4200 will be limited to internal only.|
 |service.annotations|String|None|Annotations for the the service component - this is where you'll want to put load balancer specific configuration directives|
 |criblImage.tag|String|latest|The container image tag to pull from. By default this will use the latest release, but you can also use version tags (like "2.3.2") to pull specific versions of LogStream|
 

--- a/helm-chart-sources/logstream-master/values.yaml
+++ b/helm-chart-sources/logstream-master/values.yaml
@@ -31,7 +31,7 @@ config:
 env: {}
 
 service:
-  internalType: LoadBalancer
+  internalType: ClusterIP
   externalType: LoadBalancer
   annotations: {}
 


### PR DESCRIPTION
For security reasons we restrict the worker to master port 4200 to cluster internal by default with the option to override if necessary by the deployer.

Happy to discuss with you @stevelitras if this makes sense or not.