### PR TITLE
remove required license config for mount initial-config 

### DIFF
--- a/helm-chart-sources/logstream-master/templates/deployment.yaml
+++ b/helm-chart-sources/logstream-master/templates/deployment.yaml
@@ -32,10 +32,8 @@ spec:
           volumeMounts:
           - name: config-storage
             mountPath: {{ .Values.config.criblHome }}/config-volume
-          {{- if  .Values.config.license  }}
           - name: initial-config
             mountPath: /var/tmp/config_bits
-          {{- end }}
           ports:
             {{-  range .Values.service.ports }}
             - name: {{ .name }}
@@ -70,7 +68,7 @@ spec:
             # Single Volume for persistents (CRIBL-3848)
             - name: CRIBL_VOLUME_DIR
               value: {{ .Values.config.criblHome }}/config-volume
-            
+
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value }}
@@ -104,14 +102,14 @@ spec:
           command: ["/bin/ash","-c"]
           args:
             - for dir in local data state groups; do
-                if [ ! -d {{ .Values.config.criblHome }}/config-volume/$dir ]; then 
-                  (cd {{ .Values.config.criblHome }}; tar cf - --exclude lost+found .) | (cd {{ .Values.config.criblHome }}/config-volume; tar xf -); 
+                if [ ! -d {{ .Values.config.criblHome }}/config-volume/$dir ]; then
+                  (cd {{ .Values.config.criblHome }}; tar cf - --exclude lost+found .) | (cd {{ .Values.config.criblHome }}/config-volume; tar xf -);
                 fi
               done
-  
+
           volumeMounts:
             - name: config-storage
-              mountPath: {{ .Values.config.criblHome }}/config-volume        
+              mountPath: {{ .Values.config.criblHome }}/config-volume
             - name: local-storage
               mountPath: {{ .Values.config.criblHome }}/local
             - name: data-storage


### PR DESCRIPTION
Hi I tried to installed with helm, and found without setting license, the master complains about No such file.
```
ls-master-76dff84df6-sj7mt logstream-master cp: cannot stat '/var/tmp/config_bits/groups.yml': No such file or directory
ls-master-76dff84df6-sj7mt logstream-master cp: cannot stat '/var/tmp/config_bits/mappings.yml': No such file or directory
ls-master-76dff84df6-sj7mt logstream-master cp: cannot stat '/var/tmp/config_bits/users.json': No such file or directory
```

turns out if the license is not set, the `mountPath` will not be there, 
I'm not 100% sure if license is really required, but it can still run without one, and I think it's good for people want to try it out (like me).
Please feel free to suggest or edit, thanks!