### PR TITLE
Add annotations for Worker Group RBAC to allow usage of AWS IAM Roles.

### DIFF
--- a/common_docs/EKS_SPECIFICS.md
+++ b/common_docs/EKS_SPECIFICS.md
@@ -30,6 +30,18 @@ ingress:
 
 This example sets the ingress's class to `alb`, which tells the controller to use an ALB. It tells it to listen on port 80, and it sets the "scheme" to internet-facing, which provisions an ALB with a routable internet address.
 
+## AWS IAM Role for Worker Group
+
+To allow pods to use IAM Roles, you first need to configure an IAM OIDC Provider and IAM Role. You can read more about the required configs on the AWS Docs site: [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html)
+
+Once the OIDC Provider and IAM Role have been configured, add the following to your `values.yaml` file (update the placeholders with the appropriate values):
+
+```
+rbac:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::01234567890:role/your-iam-role-name-for-logstream-worker-group
+```
 
 ## Known EKS Problems
 

--- a/helm-chart-sources/logstream-workergroup/README.md
+++ b/helm-chart-sources/logstream-workergroup/README.md
@@ -44,6 +44,7 @@ This section covers the most likely values to override. To see the full scope of
 |rbac.create|false|Enable Service Account Role & Binding Creation. |
 |rbac.resources|["pods"]|Set the resource boundary for the role being created (K8s resources). |
 |rbac.verbs|["get", "list"]|Set the API verbs allowed the role (defaults to read ops). |
+|rbac.annotations|{}|Sets annotations on the Service Account. Useful for [accessing cloud resources through IAM roles](../../common_docs/EKS_SPECIFICS.md#aws-iam-role-for-worker-group).|
 |nodeSelector|{}|Add nodeSelector values to define which nodes the pods are scheduled on - see [k8s Documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) for details and allowed values. |
 |__Extra Configuration Options__|
 |[extraVolumeMounts](../../common_docs/EXTRA_EXAMPLES.md#extraVolumeMounts)|{}|Additional Volumes to mount in the container.|

--- a/helm-chart-sources/logstream-workergroup/templates/serviceaccount.yaml
+++ b/helm-chart-sources/logstream-workergroup/templates/serviceaccount.yaml
@@ -5,4 +5,7 @@ metadata:
   name: {{ include "logstream-workergroup.fullname" . }}
   labels:
     {{- include "logstream-workergroup.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.rbac.annotations  | nindent 4 }}
+
 {{- end }}

--- a/helm-chart-sources/logstream-workergroup/values.yaml
+++ b/helm-chart-sources/logstream-workergroup/values.yaml
@@ -13,6 +13,7 @@ rbac:
   verbs:
   - get
   - list
+  annotations: {}
 
 criblImage:
   repository: cribl/cribl


### PR DESCRIPTION
Required for allows EKS service accounts to use an IAM role.

https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html