### PR TITLE
revving to 3.2.2, using the 3.2.2 container tag

### DIFF
--- a/helm-chart-sources/logstream-leader/Chart.yaml
+++ b/helm-chart-sources/logstream-leader/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.1
+version: 3.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.2.1
+appVersion: 3.2.2

--- a/helm-chart-sources/logstream-leader/values.yaml
+++ b/helm-chart-sources/logstream-leader/values.yaml
@@ -9,7 +9,7 @@ criblImage:
   repository: cribl/cribl
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "3.2.1"
+  tag: "3.2.2"
 
 imagePullSecrets: []
 nameOverride: "leader"

--- a/helm-chart-sources/logstream-workergroup/Chart.yaml
+++ b/helm-chart-sources/logstream-workergroup/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.1
+version: 3.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.2.1
+appVersion: 3.2.2

--- a/helm-chart-sources/logstream-workergroup/values.yaml
+++ b/helm-chart-sources/logstream-workergroup/values.yaml
@@ -19,7 +19,7 @@ criblImage:
   repository: cribl/cribl
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "3.2.1"
+  tag: "3.2.2"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
updated versions in Chart.yamls, and updated tag to 3.2.2 in values files. 