### PR TITLE
Edge demo changes

### DIFF
--- a/common_docs/EXTRA_EXAMPLES.md
+++ b/common_docs/EXTRA_EXAMPLES.md
@@ -118,6 +118,82 @@ extraVolumeMounts:
   readOnly: false
 ```
 
+## Using extraContainers <a name="extraContainers"></a>
+_Availability: logstream-workergroup and logstream-master_
+
+The `extraContainers` option allows you to run one or more sidecar containers along with the main LogStream container. This allows you to implement the standard sidecar pattern with the logstream helm charts. This takes one or more container definitions.
+
+### Example
+Here is an simple container definition that uses the fluentd container as a sidecar, also mounting the config-storage volume from the logstream container within the sidecar. 
+
+```
+extraContainers:
+- name: fluentd
+  image: "fluentd"
+  volumeMounts:
+    - mountPath: /my_mounts/cribl-config
+      name: config-storage
+
+```
+
+## Using extraInitContainers <a name="extraInitContainers"></a>
+_Availability: logstream-workergroup and logstream-master_
+
+The `extraInitContainers` option allows you to run one or more `initContainer`s before the main LogStream worker container starts up. This can be useful for making OS-level changes to a persistent volume (like `chown` or `chmod` of files or directories), among other things. This takes one or more container definitions.
+
+### Example
+Here is an extremely simple container definition that uses the base alpine container image and changes the permissions on the directory `/opt/mypath` to 755.
+
+```
+extraInitContainers:
+- name: testing
+  image: "alpine:latest"
+  command: ["/bin/ash", "-c"]
+  args:
+    - chmod 755 /opt/mypath
+```
+
+## Using securityContext <a name="securityContext"></a>
+_Availability: logstream-workergroup and logstream-master_
+
+The `securityContext` option allows you to define a user ID and a group ID to run the container processes under. When you do this, the first step the container goes through, prior to starting LogStream, is to `chown` the `/opt/cribl` directory (recursively) to that user/group ID. On the logstream-master chart, it also `chown`s the `/opt/cribl/config-volume` directory tree. It then starts the `entrypoint.sh` script as the specified user.
+
+### Example
+This example runs the processes under the user ID of `1020` and the group ID of `30`. 
+
+```
+securityContext:
+  runAsUser: 1020
+  runAsGroup: 30
+```
+
+## env <a name="env"></a>
+_Availability: logstream-workergroup and logstream-master_
+
+The `env` option allows you to specify additional static environment variables for the container. This takes a set of key-value pairs.
+
+### Example
+This example creates two environment variables, `DATA_DIR` and `JOB_ID`.
+
+```
+env: 
+  DATA_DIR: "/var/tmp/data"
+  JOB_ID: "reconciliation"
+```
+
+## rbac.extraRules <a name="rbac.extraRules"></a>
+_Availability: logstream-workergroup_
+
+The `rbac.extraRules` option allows you to specify additional RBAC rules into the RBAC setup for logstream-workergroup. It does require `rbac.create` to be set to `true`. it takes a list of maps, just like the rules in a Kubernetes role. 
+
+### Example
+This example provides access to `deployments`, allowing verbs `get`, `list`, `watch`, `create`, `update`, `patch`, and `delete`, for the API groups `extensions` and `apps`.
+
+```
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+```
 ## Using extraInitContainers <a name="extraInitContainers"></a>
 _Availability: logstream-workergroup and logstream-master_
 

--- a/common_docs/EXTRA_EXAMPLES.md
+++ b/common_docs/EXTRA_EXAMPLES.md
@@ -1,5 +1,5 @@
 ## Using envValueFrom<a name="envValueFrom"></a>
-_Availability: logstream-workergroup and logstream-master_
+_Availability: logstream-workergroup and logstream-leader_
 
 The `envValueFrom` option takes a list of maps, just as the `env` attribute does in K8s manifests. The documentation for exposing Downward API data like this is available on this [K8s Doc Page](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/).
 
@@ -20,7 +20,7 @@ envValueFrom:
 ```
 
 ## Using extraConfigMapMounts <a name="extraConfigmapMounts"></a>
-_Availability: logstream-workergroup and logstream-master_
+_Availability: logstream-workergroup and logstream-leader_
 
 The `extraConfigmapMounts` option allows you to mount a `ConfigMap` object within a pod. It takes a list of maps to define each `ConfigMap` you wish to mount. It uses a subset of the fields that you'd normally use in a `volumeMount`. Fields:
 
@@ -49,7 +49,7 @@ extraConfigmapMounts:
 ```
 
 ## Using extraSecretMounts <a name="extraSecretMounts"></a>
-_Availability: logstream-workergroup and logstream-master_
+_Availability: logstream-workergroup and logstream-leader_
 
 The `extraSecretMounts` option allows you to mount a K8s [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) object within a pod. It takes a list of maps that define each Secret you wish to mount. It uses a subset of the fields that you'd normally use in a `volumeMount`. Fields:
 
@@ -79,7 +79,7 @@ extraSecretMounts:
 ```
 
 ## Using extraVolumeMounts <a name="extraVolumeMounts"></a>
-_Availability: logstream-workergroup and logstream-master_
+_Availability: logstream-workergroup and logstream-leader_
 
 The `extraVolumeMounts` option allows you to mount multiple volume types within a pod. If you specify an `existingClaim` attribute, it will mount the specified Persistent Volume Claim (PVC) as a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). If you instead specify a `hostPath` attribute, it will mount that path from the host node into the Pod as a [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) volume. If you include neither, `extraVolumeMounts` will treat the definition as an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) mount.
 
@@ -119,7 +119,7 @@ extraVolumeMounts:
 ```
 
 ## Using extraContainers <a name="extraContainers"></a>
-_Availability: logstream-workergroup and logstream-master_
+_Availability: logstream-workergroup and logstream-leader_
 
 The `extraContainers` option allows you to run one or more sidecar containers along with the main LogStream container. This allows you to implement the standard sidecar pattern with the logstream helm charts. This takes one or more container definitions.
 
@@ -137,7 +137,7 @@ extraContainers:
 ```
 
 ## Using extraInitContainers <a name="extraInitContainers"></a>
-_Availability: logstream-workergroup and logstream-master_
+_Availability: logstream-workergroup and logstream-leader_
 
 The `extraInitContainers` option allows you to run one or more `initContainer`s before the main LogStream worker container starts up. This can be useful for making OS-level changes to a persistent volume (like `chown` or `chmod` of files or directories), among other things. This takes one or more container definitions.
 
@@ -154,9 +154,9 @@ extraInitContainers:
 ```
 
 ## Using securityContext <a name="securityContext"></a>
-_Availability: logstream-workergroup and logstream-master_
+_Availability: logstream-workergroup and logstream-leader_
 
-The `securityContext` option allows you to define a user ID and a group ID to run the container processes under. When you do this, the first step the container goes through, prior to starting LogStream, is to `chown` the `/opt/cribl` directory (recursively) to that user/group ID. On the logstream-master chart, it also `chown`s the `/opt/cribl/config-volume` directory tree. It then starts the `entrypoint.sh` script as the specified user.
+The `securityContext` option allows you to define a user ID and a group ID to run the container processes under. When you do this, the first step the container goes through, prior to starting LogStream, is to `chown` the `/opt/cribl` directory (recursively) to that user/group ID. On the logstream-leader chart, it also `chown`s the `/opt/cribl/config-volume` directory tree. It then starts the `entrypoint.sh` script as the specified user.
 
 ### Example
 This example runs the processes under the user ID of `1020` and the group ID of `30`. 
@@ -168,7 +168,7 @@ securityContext:
 ```
 
 ## env <a name="env"></a>
-_Availability: logstream-workergroup and logstream-master_
+_Availability: logstream-workergroup and logstream-leader_
 
 The `env` option allows you to specify additional static environment variables for the container. This takes a set of key-value pairs.
 
@@ -195,7 +195,7 @@ This example provides access to `deployments`, allowing verbs `get`, `list`, `wa
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ```
 ## Using extraInitContainers <a name="extraInitContainers"></a>
-_Availability: logstream-workergroup and logstream-master_
+_Availability: logstream-workergroup and logstream-leader_
 
 The `extraInitContainers` option allows you to run one or more `initContainer`s before the main LogStream worker container starts up. This can be useful for making OS-level changes to a persistent volume (like `chown` or `chmod` of files or directories), among other things. This takes one or more container definitions.
 
@@ -212,9 +212,9 @@ extraInitContainers:
 ```
 
 ## Using securityContext <a name="securityContext"></a>
-_Availability: logstream-workergroup and logstream-master_
+_Availability: logstream-workergroup and logstream-leader_
 
-The `securityContext` option allows you to define a user ID and a group ID to run the container processes under. When you do this, the first step the container goes through, prior to starting LogStream, is to `chown` the `/opt/cribl` directory (recursively) to that user/group ID. On the logstream-master chart, it also `chown`s the `/opt/cribl/config-volume` directory tree. It then starts the `entrypoint.sh` script as the specified user.
+The `securityContext` option allows you to define a user ID and a group ID to run the container processes under. When you do this, the first step the container goes through, prior to starting LogStream, is to `chown` the `/opt/cribl` directory (recursively) to that user/group ID. On the logstream-leader chart, it also `chown`s the `/opt/cribl/config-volume` directory tree. It then starts the `entrypoint.sh` script as the specified user.
 
 ### Example
 This example runs the processes under the user ID of `1020` and the group ID of `30`. 
@@ -226,7 +226,7 @@ securityContext:
 ```
 
 ## env <a name="env"></a>
-_Availability: logstream-workergroup and logstream-master_
+_Availability: logstream-workergroup and logstream-leader_
 
 The `env` option allows you to specify additional static environment variables for the container. This takes a set of key-value pairs.
 

--- a/helm-chart-sources/logstream-leader/README.md
+++ b/helm-chart-sources/logstream-leader/README.md
@@ -65,6 +65,7 @@ This section covers the most likely values to override. To see the full scope of
 |[extraSecretMounts](../../common_docs/EXTRA_EXAMPLES.md#extraSecretMounts)|[]|Pre-existing secrets to mount within the container. |
 |[extraConfigmapMounts](../../common_docs/EXTRA_EXAMPLES.md#extraConfigmapMounts)|{}|Pre-existing configmaps to mount within the container. |
 |[extraInitContainers](../../common_docs/EXTRA_EXAMPLES.md#extraInitContainers)|{}|Additional containers to run ahead of the primary container in the pod.|
+|[extraContainers](../../common_docs/EXTRA_EXAMPLES.md#extraContainers)|{}|Additional containers to run as sidecars of the primary container in the pod.|
 |[securityContext.runAsUser](../../common_docs/EXTRA_EXAMPLES.md#securityContext)|0|User ID to run the container processes under.|
 |[securityContext.runAsGroup](../../common_docs/EXTRA_EXAMPLES.md#securityContext)|0|Group ID to run the container processes under.|
 |[envValueFrom](../../common_docs/EXTRA_EXAMPLES.md#extraEnvFrom)|{}|Environment variables to be exposed from the Downward API.|

--- a/helm-chart-sources/logstream-leader/templates/_pod.tpl
+++ b/helm-chart-sources/logstream-leader/templates/_pod.tpl
@@ -112,6 +112,10 @@ containers:
         value: "[ ! -f $CRIBL_VOLUME_DIR/users_imported ] && sleep 20 && cp /var/tmp/config_bits/users.json $CRIBL_VOLUME_DIR/local/cribl/auth/users.json && touch $CRIBL_VOLUME_DIR/users_imported"
         {{- $a_iter = add $a_iter 1 }} 
      {{- end }}
+{{- with .Values.extraContainers }}
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+
 initContainers:
 {{- with .Values.extraInitContainers }}
   {{- toYaml . | nindent 8 }}
@@ -197,6 +201,7 @@ volumes:
     csi: {{- toYaml .csi | nindent 6 }}
 {{- end }}
 {{- end }}
+
 
 {{- with .Values.nodeSelector }}
 nodeSelector:

--- a/helm-chart-sources/logstream-workergroup/README.md
+++ b/helm-chart-sources/logstream-workergroup/README.md
@@ -33,6 +33,8 @@ This section covers the most likely values to override. To see the full scope of
 |config.host|"logstream-leader"|The resolvable hostname of your LogStream leader. |
 |config.rejectSelfSignedCerts|0| One of: `0` – allow self-signed certs; or `1` – deny self-signed certs. |
 |config.tlsLeader.enable|false|Enable TLS connectivity from the workergroup to its leader node |
+|config.hostNetwork|false|configures the workergroup to use the K8s host network instead of the container network.|
+|config.noProbe|false|turns off the liveness and readiness probs.|
 |service.type|LoadBalancer|The type of service to create for the workergroup|
 |service.loadBalancerIP|none (IP Address)|The IP address to use for the load balancer service interface, if the type is set to LoadBalancer. Check with your Kubernetes setup to see if this is supported. |
 |service.ports|<pre>- name: tcpjson<br>  port: 10001<br>  protocol: TCP<br>- name: s2s<br>  port: 9997<br>  protocol: TCP<br>- name: http<br>  port: 10080<br>  protocol: TCP<br>- name: https<br>  port: 10081<br>  protocol: TCP<br>- name: syslog<br>  port: 5140<br>  protocol: TCP<br>- name: metrics<br>  port: 8125<br>  protocol: TCP<br>- name: elastic<br>  port: 9200<br>  protocol: TCP</pre>|The ports to make available both in the Deployment and the Service. Each "map" in the list needs the following values set: <dl><dt>name</dt><dd>A descriptive name of what the port is being used for.</dd><dt>port</dt><dd>The port to make available.</dd><dt>protocol</dt><dd>The protocol in use for this port (UDP/TCP).</dd></dl>|

--- a/helm-chart-sources/logstream-workergroup/README.md
+++ b/helm-chart-sources/logstream-workergroup/README.md
@@ -53,6 +53,7 @@ This section covers the most likely values to override. To see the full scope of
 |[extraSecretMounts](../../common_docs/EXTRA_EXAMPLES.md#extraSecretMounts)|[]|Pre-existing secrets to mount within the container. |
 |[extraConfigmapMounts](../../common_docs/EXTRA_EXAMPLES.md#extraConfigmapMounts)|{}|Pre-existing configmaps to mount within the container. |
 |[extraInitContainers](../../common_docs/EXTRA_EXAMPLES.md#extraInitContainers)|{}|Additional containers to run ahead of the primary container in the pod.|
+|[extraContainers](../../common_docs/EXTRA_EXAMPLES.md#extraContainers)|{}|Additional containers to run as sidecars of the primary container in the pod.|
 |[securityContext.runAsUser](../../common_docs/EXTRA_EXAMPLES.md#securityContext)|0|User ID to run the container processes under.|
 |[securityContext.runAsGroup](../../common_docs/EXTRA_EXAMPLES.md#securityContext)|0|Group ID to run the container processes under.|
 |[envValueFrom](../../common_docs/EXTRA_EXAMPLES.md#extraEnvFrom)|{}|Environment variables to be exposed from the Downward API.|

--- a/helm-chart-sources/logstream-workergroup/README.md
+++ b/helm-chart-sources/logstream-workergroup/README.md
@@ -34,7 +34,7 @@ This section covers the most likely values to override. To see the full scope of
 |config.rejectSelfSignedCerts|0| One of: `0` – allow self-signed certs; or `1` – deny self-signed certs. |
 |config.tlsLeader.enable|false|Enable TLS connectivity from the workergroup to its leader node |
 |config.hostNetwork|false|configures the workergroup to use the K8s host network instead of the container network.|
-|config.noProbe|false|turns off the liveness and readiness probs.|
+|config.probes|true|enables (true) or disables (false) the liveness and readiness probes.|
 |service.type|LoadBalancer|The type of service to create for the workergroup|
 |service.loadBalancerIP|none (IP Address)|The IP address to use for the load balancer service interface, if the type is set to LoadBalancer. Check with your Kubernetes setup to see if this is supported. |
 |service.ports|<pre>- name: tcpjson<br>  port: 10001<br>  protocol: TCP<br>- name: s2s<br>  port: 9997<br>  protocol: TCP<br>- name: http<br>  port: 10080<br>  protocol: TCP<br>- name: https<br>  port: 10081<br>  protocol: TCP<br>- name: syslog<br>  port: 5140<br>  protocol: TCP<br>- name: metrics<br>  port: 8125<br>  protocol: TCP<br>- name: elastic<br>  port: 9200<br>  protocol: TCP</pre>|The ports to make available both in the Deployment and the Service. Each "map" in the list needs the following values set: <dl><dt>name</dt><dd>A descriptive name of what the port is being used for.</dd><dt>port</dt><dd>The port to make available.</dd><dt>protocol</dt><dd>The protocol in use for this port (UDP/TCP).</dd></dl>|

--- a/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
+++ b/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
@@ -29,7 +29,7 @@ containers:
       chown  -R   "{{- .Values.securityContext.runAsUser }}:{{- .Values.securityContext.runAsGroup }}" /opt/cribl
       gosu "{{- .Values.securityContext.runAsUser }}:{{- .Values.securityContext.runAsGroup }}" /sbin/entrypoint.sh cribl
     {{- end }}
-    {{- if not .Values.config.noProbes }}
+    {{- if .Values.config.probes }}
     livenessProbe:
       httpGet:
         path: /api/v1/health

--- a/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
+++ b/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
@@ -95,12 +95,17 @@ containers:
     resources:
       {{- toYaml .Values.resources | nindent 12 }}
 
+{{- with .Values.extraContainers }}
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+
+
 {{- with .Values.nodeSelector }}
 nodeSelector:
   {{- toYaml .  | nindent 2 }}
 {{- end }}
 
-volumes:
+volumes: 
   {{- range .Values.extraVolumeMounts }}
   - name: {{ .name }}
     {{- if .existingClaim }}

--- a/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
+++ b/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
@@ -11,6 +11,9 @@ imagePullSecrets:
 initContainers:
   {{- toYaml . | nindent 8 }}
 {{- end }}
+{{- if .Values.config.hostNetwork }}
+hostNetwork: true
+{{- end }}
 containers:
   - name: {{ .Chart.Name }}
     image: "{{ .Values.criblImage.repository }}:{{ .Values.criblImage.tag | default .Chart.AppVersion }}"
@@ -26,6 +29,7 @@ containers:
       chown  -R   "{{- .Values.securityContext.runAsUser }}:{{- .Values.securityContext.runAsGroup }}" /opt/cribl
       gosu "{{- .Values.securityContext.runAsUser }}:{{- .Values.securityContext.runAsGroup }}" /sbin/entrypoint.sh cribl
     {{- end }}
+    {{- if not .Values.config.noProbes }}
     livenessProbe:
       httpGet:
         path: /api/v1/health
@@ -44,6 +48,7 @@ containers:
         {{- end }}
       failureThreshold: 3
       initialDelaySeconds: 20
+    {{- end }}
     env:
       - name: CRIBL_DIST_MASTER_URL
         valueFrom:

--- a/helm-chart-sources/logstream-workergroup/values.yaml
+++ b/helm-chart-sources/logstream-workergroup/values.yaml
@@ -30,6 +30,7 @@ config:
   token: criblleader
   rejectSelfSignedCerts: 0
   healthPort: 9000
+  probes: true
   tlsLeader:
     enable: false
 


### PR DESCRIPTION
This implements a few new config options:
- extraContainers - implements the sidecar pattern, addressing issue #29 
- config.hostNetwork - implements deploying the chart on the hostNetwork, which will enable node wide network metrics for the edge product.
- config.noProbes - allows disabling of the liveness and readiness probes.