### PR TITLE
Rbac improvements

### DIFF
--- a/helm-chart-sources/logstream-workergroup/README.md
+++ b/helm-chart-sources/logstream-workergroup/README.md
@@ -44,8 +44,9 @@ This section covers the most likely values to override. To see the full scope of
 |autoscaling.maxReplicas|10|The maximum number of LogStream pods to scale to run.|
 |autoscaling.targetCPUUtilizationPercentage|50|The CPU utilization percentage that triggers scaling. |
 |rbac.create|false|Enable Service Account Role & Binding Creation. |
-|rbac.resources|["pods"]|Set the resource boundary for the role being created (K8s resources). |
-|rbac.verbs|["get", "list"]|Set the API verbs allowed the role (defaults to read ops). |
+|rbac.apiGroups|{core}|Set the apiGroups in roles rules|
+|rbac.resources|{pods}|Set the resource boundary for the role being created (K8s resources). |
+|rbac.verbs|{get,list}|Set the API verbs allowed the role (defaults to read ops). |
 |rbac.annotations|{}|Sets annotations on the Service Account. Useful for [accessing cloud resources through IAM roles](../../common_docs/EKS_SPECIFICS.md#aws-iam-role-for-worker-group).|
 |nodeSelector|{}|Add nodeSelector values to define which nodes the pods are scheduled on - see [k8s Documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) for details and allowed values. |
 |__Extra Configuration Options__|

--- a/helm-chart-sources/logstream-workergroup/README.md
+++ b/helm-chart-sources/logstream-workergroup/README.md
@@ -4,8 +4,13 @@
 
 This Chart deploys a Cribl LogStream worker group.
 
+# IMPORTANT
+A change has been made in this version that changes the syntax for the rbac values. Please see the
+table below for values options for the rbac.apiGroups, rbac.verbs, and rbac.resources before you
+upgrade the chart.
+
 # New Capabilities
-* support for the 3.1.0 version of LogStream (default version)
+* support for the 3.4.0 version of LogStream (default version)
 
 # Deployment
 

--- a/helm-chart-sources/logstream-workergroup/templates/role.yaml
+++ b/helm-chart-sources/logstream-workergroup/templates/role.yaml
@@ -7,9 +7,18 @@ metadata:
   labels:
     {{- include "logstream-workergroup.labels" . | nindent 4 }}
 rules:
-  - apiGroups: {{ .Values.rbac.apiGroups }}
-    resources: {{ .Values.rbac.resources }}
-    verbs: {{ .Values.rbac.verbs }}
+  - apiGroups: 
+    {{- with .Values.rbac.apiGroups }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    resources: 
+    {{- with .Values.rbac.resources }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    verbs: 
+    {{- with .Values.rbac.verbs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.rbac.extraRules }}
     {{- toYaml . | nindent 2 }}
   {{- end }}


### PR DESCRIPTION
Changed the rbac set up a little bit, as the previous config didn't allow multiple entries to be provided for apiGroups, verbs or resources. That's fixed and an "IMPORTANT" section has been added to the README for it - this was only on logstream-workergroup.