### PR TITLE
Add tolerations to the logstream-workergroup template

### DIFF
--- a/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
+++ b/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
@@ -105,6 +105,11 @@ nodeSelector:
   {{- toYaml .  | nindent 2 }}
 {{- end }}
 
+{{- with .Values.tolerations }}
+tolerations:
+  {{- toYaml . | nindent 8 }}
+{{- end }}
+
 volumes: 
   {{- range .Values.extraVolumeMounts }}
   - name: {{ .name }}


### PR DESCRIPTION
Noticed that tolerations were part of the leader template but not the WG, and we had need for them, so contributing this one back.