### PR TITLE
[leader] allow specification of ingress host

### DIFF
--- a/helm-chart-sources/logstream-leader/templates/ingress.yaml
+++ b/helm-chart-sources/logstream-leader/templates/ingress.yaml
@@ -8,7 +8,12 @@ metadata:
 
 spec:
   rules:
+  {{- if .Values.ingress.host }}
+  - host: {{ .Values.ingress.host }}
+    http:
+  {{- else }}
   - http:
+  {{- end }}
       paths:
       - path: /*
         pathType: Prefix

--- a/helm-chart-sources/logstream-leader/values.yaml
+++ b/helm-chart-sources/logstream-leader/values.yaml
@@ -53,6 +53,7 @@ securityContext: {}
 
 ingress:
   enable: false
+  host:
   annotations: {}
 
 resources:


### PR DESCRIPTION
Current chart doesn't allow for specifying a host in the ingress definition. This PR adds the optionality to specify a host. Didn't go fancy and allow multiple definitions, so this assumes just one host value to be specified. 

Didn't replicate to master as it looks like that might be deprecated? Lmk, easy enough to copy it across. Worker group doesn't have an external ingress so no need here