### PR TITLE
add deployment rollout strategy to leader

### DIFF
--- a/helm-chart-sources/logstream-leader/templates/deployment.yaml
+++ b/helm-chart-sources/logstream-leader/templates/deployment.yaml
@@ -12,6 +12,23 @@ spec:
   selector:
     matchLabels:
       {{- include "logstream-leader.selectorLabels" . | nindent 6 }}
+  {{- $strategy := default "Recreate" .Values.strategy.type }}
+  {{- if and (ne $strategy "Recreate") (ne $strategy "RollingUpdate") }}
+    {{- fail (printf "Not a valid strategy type for Deployment (%s)" $strategy) }}
+  {{- end }}
+  strategy:
+    type: {{ $strategy }}
+    {{- with .Values.strategy.rollingUpdate }}
+      {{- if and (eq $strategy "RollingUpdate") (or .surge .unavailable) }}
+    rollingUpdate:
+        {{- with .unavailable }}
+      maxUnavailable: {{ . }}
+        {{- end }}
+        {{- with .surge }}
+      maxSurge: {{ . }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
   template:
     metadata:
     {{- with .Values.podAnnotations }}

--- a/helm-chart-sources/logstream-leader/values.yaml
+++ b/helm-chart-sources/logstream-leader/values.yaml
@@ -45,6 +45,12 @@ service:
       protocol: TCP
       external: false
 
+strategy:
+  type: Recreate
+  rollingUpdate:
+    maxSurge:
+    maxUnavailable:
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
Adding the ability to configure the leader's deployment rollout strategy. Since the leader always has a PVC, the default k8s rollout strategy of `RollingUpdate` will never resolve correctly (because the claims helm template specifies `ReadWriteOnce` but also because most storage types people would be deploying are typically `ReadWriteOnce`). Left the optionality to configure it, but really it should default to `Recreate` with the PVC as defined. Happy to update PR if desired to reduce complexity of the chart.

Tested by `helm template` with both `Recreate` and `RollingUpdate` values