### PR TITLE
HPA stabilization

### DIFF
--- a/helm-chart-sources/logstream-workergroup/README.md
+++ b/helm-chart-sources/logstream-workergroup/README.md
@@ -46,6 +46,7 @@ This section covers the most likely values to override. To see the full scope of
 |autoscaling.minReplicas|2|The minimum number of Cribl Stream pods to run.|
 |autoscaling.maxReplicas|10|The maximum number of Cribl Stream pods to scale to run.|
 |autoscaling.targetCPUUtilizationPercentage|50|The CPU utilization percentage that triggers scaling. |
+|autoscaling.behavior|{}|[Scaling behavior configuration](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior)|
 |rbac.create|false|Enable Service Account Role & Binding Creation. |
 |rbac.apiGroups|{core}|Set the apiGroups in roles rules|
 |rbac.resources|{pods}|Set the resource boundary for the role being created (K8s resources). |

--- a/helm-chart-sources/logstream-workergroup/templates/hpa.yaml
+++ b/helm-chart-sources/logstream-workergroup/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
+apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   {{- if .Values.config.group }}
@@ -17,17 +21,25 @@ spec:
     name: {{ include "logstream-workergroup.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   metrics:
   {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
   {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
 {{- end }}

--- a/helm-chart-sources/logstream-workergroup/values.yaml
+++ b/helm-chart-sources/logstream-workergroup/values.yaml
@@ -80,4 +80,17 @@ autoscaling:
   minReplicas: 2
   maxReplicas: 10
   targetCPUUtilizationPercentage: 50
+  behavior: {}
+#    scaleUp:
+#     stabilizationWindowSeconds: 300
+#     policies:
+#     - type: Pods
+#       value: 1
+#       periodSeconds: 60
+#    scaleDown:
+#     stabilizationWindowSeconds: 300
+#     policies:
+#     - type: Pods
+#       value: 1
+#       periodSeconds: 180
 


### PR DESCRIPTION
* v2beta1 is deprecated for newer clusters 1.22+
* Allow for customizable scaling behavior

Resolves #61 