### PR TITLE
Add Common and Edge charts for 4.0.0 launch

### DIFF
--- a/helm-chart-sources/common/.helmignore
+++ b/helm-chart-sources/common/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-chart-sources/common/Chart.yaml
+++ b/helm-chart-sources/common/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: common
+description: Common templates for Cribl Helm Charts
+maintainers:
+  - name: Cribl, Inc.
+    email: support@cribl.io
+    url: https://github.com/criblio/helm-charts
+type: library
+version: 1.0.0
+appVersion: 1.0.0

--- a/helm-chart-sources/common/README.md
+++ b/helm-chart-sources/common/README.md
@@ -1,0 +1,4 @@
+# Cribl Common Chart
+
+This is a template chart providing resources to other application charts. It is not meant to be directly deployed.
+

--- a/helm-chart-sources/common/templates/_extras.tpl
+++ b/helm-chart-sources/common/templates/_extras.tpl
@@ -1,0 +1,6 @@
+{{- define "common.extras" }}
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}
+{{- end }}

--- a/helm-chart-sources/common/templates/_helpers.tpl
+++ b/helm-chart-sources/common/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "common.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "common.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "common.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "common.labels" -}}
+helm.sh/chart: {{ include "common.chart" . }}
+{{ include "common.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "common.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "common.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "common.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "common.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm-chart-sources/common/templates/_ingress.yaml
+++ b/helm-chart-sources/common/templates/_ingress.yaml
@@ -1,0 +1,41 @@
+{{- define "common.ingress" -}}
+{{- if eq .Values.ingress.enable true }}
+{{- range .Values.ingress.ingress }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "common.fullname" $ }}-{{ .name }}
+  {{- if or (($.Values.ingress).annotations) .annotations }}
+  annotations:
+    {{- $annotations := merge (.annotations) (($.Values.ingress).annotations) }}
+    {{- toYaml $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if or (($.Values.ingress).className) (.className) }}
+  ingressClassName: {{ coalesce (.className) $.Values.ingress.className }}
+  {{- end }}
+  rules:
+  {{- range .rules }}
+    - http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .kind | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "common.fullname" $ }}
+                port:
+                  number: {{ .port }}
+          {{- end }}
+    {{- if .host }}
+      host: {{ .host | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm-chart-sources/common/templates/_secret.tpl
+++ b/helm-chart-sources/common/templates/_secret.tpl
@@ -1,0 +1,18 @@
+{{- define "common.secret" -}}
+{{- if or (not ((.Values.cribl).existingSecretForLeader)) ((.Values.cribl).config) }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "common.fullname" . }}-cribl-settings
+stringData:
+  {{- if or (not ((.Values.cribl).existingSecretForLeader)) ((.Values.cribl).leader) }}
+  CRIBL_DIST_LEADER_URL: {{ required "A valid CRIBL_DIST_MASTER_URL is required to be defined in the cribl.leader value!" (.Values.cribl).leader }}
+  {{- end }}
+  {{- if .Values.cribl.config }}
+  CRIBL_BOOTSTRAP: |
+  {{- .Values.cribl.config | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm-chart-sources/common/values.yaml
+++ b/helm-chart-sources/common/values.yaml
@@ -1,0 +1,2 @@
+# cribl/common
+cribl: true

--- a/helm-chart-sources/edge/.helmignore
+++ b/helm-chart-sources/edge/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-chart-sources/edge/Chart.yaml
+++ b/helm-chart-sources/edge/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: edge
+description: A Helm chart for Kubernetes
+type: application
+version: 4.0.0
+appVersion: "4.0.0"
+icon: https://criblio.github.io/helm-charts/images/Cribl_Logo_Color_TM.png
+
+dependencies:
+  - name: common
+    version: 1.0.0
+    repository: https://criblio.github.io/helm-charts

--- a/helm-chart-sources/edge/README.md
+++ b/helm-chart-sources/edge/README.md
@@ -1,0 +1,82 @@
+![Cribl Logo](../../images/Cribl_Logo_Color_TM.png)
+
+# Edge Helm Chart
+
+This chart deploys a Cribl Edge DaemonSet in a Kubernetes Cluster.
+
+# Deployment
+
+As built, this chart will deploy a DaemonSet on all Nodes in a K8s cluster, Service Account, Cluster Role, Cluster Role Binding, and Secret for setting the Cribl Leader configuration.
+
+When deploying this chart, you must change the Fleet API host from binding on `127.0.0.1` to `0.0.0.0`. If you do not, health checks will fail and the Pods will be continually replaced.
+
+**Note**: This chart does **not** deploy a Cribl Leader node!
+
+# Prerequisites
+
+1. Helm v3 installed – instructions are [here](https://helm.sh/docs/intro/install/).
+2. Cribl helm repo configured. To do this:
+    `helm repo add cribl https://criblio.github.io/helm-charts/`
+
+# Known Issues
+
+* This chart is not deployable on EKS Fargate. See [AWS Fargate considerations](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html#fargate-considerations) for more information.
+
+# More Info
+
+For additional documentation about this chart, see the [Cribl Docs](https://docs.cribl.io/edge/deploy-running-kubernetes) page.
+
+# Support/Feedback
+
+If you use this helm chart, we'd love to hear any feedback you might have on this chart. Join us on our [Slack Community](https://cribl.io/community) and navigate to the `#containers` channel.
+
+# Values to Override
+
+This section covers the most likely values to override. To see the full scope of values available, run `helm show values cribl/edge`. 
+
+| Key                                                                            | Default Value     | Description                                                                         |
+|--------------------------------------------------------------------------------|-------------------|-------------------------------------------------------------------------------------|
+| image.repository                                                               | `cribl/cribl`     | Docker image repository to pull images                                              |
+| image.pullPolicy                                                               | `Always`          | When will the Node pull the image                                                   |
+| image.tag                                                                      | `3.5.4`           | The Version of Cribl to deploy                                                      |
+| imagePullSecrets                                                               | `[]`              | Credentials to pull container images                                                |
+| nameOverride                                                                   |                   | Overrides the chart name                                                            |
+| fullNameOverride                                                               |                   | Overrides the Helm deployment name                                                  |
+| [extraEnv](../../common_docs/EXTRA_EXAMPLES.md#env)                            | `[]`              | Additional Static Environment Variables.                                            |
+| [extraEnvFrom](../../common_docs/EXTRA_EXAMPLES.md#extraEnvFrom)               | `[]`              | Environment variables to be exposed from the Downward API.                          |
+| [extraConfigMaps](../../common_docs/EXTRA_EXAMPLES.md#extraConfigmapMounts)    | `[]`              | Pre-existing configmaps to mount within the container.                              |
+| [extraSecretMounts](../../common_docs/EXTRA_EXAMPLES.md#extraSecretMounts)     | `[]`              | Pre-existing secrets to mount within the container.                                 |
+| [extraVolumeMounts](../../common_docs/EXTRA_EXAMPLES.md#extraVolumeMounts)     | see `values.yaml` | Additional Volumes to mount in the container.                                       |
+| [extraContainers](../../common_docs/EXTRA_EXAMPLES.md#extraContainers)         | `{}`              | Additional containers to run as sidecars of the primary container in the pod.       |
+| [extraInitContainers](../../common_docs/EXTRA_EXAMPLES.md#extraInitContainers) | `{}`              | Additional containers to run ahead of the primary container in the pod.             |
+| cribl.home                                                                     | `/opt/cribl`      | default Cribl directory                                                             |
+| cribl.existingSecretForLeader                                                  |                   | Set if using an existing secret for the leader node                                 |
+| cribl.leader                                                                   |                   | the CRIBL_DIST_LEADER_URL to configure                                              |
+| cribl.existingSecretForConfig                                                  |                   | existing bootstrap config                                                           |
+| cribl.config                                                                   |                   | bootstrap config                                                                    |
+| cribl.readinessProbe                                                           | see `values.yaml` | readiness probe config                                                              |
+| cribl.livenessProbe                                                            | see `values.yaml` | liveness probe config                                                               |
+| serviceAccount.create                                                          | `true`            | Specifies whether a service account should be created                               |
+| serviceAccount.annotations                                                     | `{}`              | Annotations to add to the service account                                           |
+| serviceAccount.name                                                            |                   | override the default generated service account name                                 |
+| serviceAccount.automountServiceAccountToken                                    | `true`            | whether the service account token should be automounted into the container          |
+| rbac.create                                                                    | `true`            | Specifies whether a role should be created                                          |
+| rbac.annotations                                                               | `{}`              | Annotations to add to the role                                                      |
+| rbac.extraRules                                                                | `[]`              | Additional rules to add to the role                                                 |
+| podAnnotations                                                                 | `{}`              | Annotations to add to the pod                                                       |
+| podSecurityContext                                                             | `{}`              | Security context for the Pod                                                        |
+| securityContext                                                                | `{}`              | Security context for the Cribl container                                            |
+| service.enable                                                                 | `false`           | Specifies whether a service should be created                                       |
+| service.type                                                                   | `ClusterIP`       | The type of service deployed                                                        |
+| service.externalTrafficPolicy                                                  | `Cluster`         | IP address visibility                                                               |
+| service.annotations                                                            | `{}`              | Annotations to add to the service                                                   |
+| service.ports                                                                  | see `values.yaml` | Ports configured for the service                                                    |
+| ingress.enable                                                                 | `false`           | Specifies if an ingress should be created                                           |
+| ingress.className                                                              |                   | The ingress class name                                                              |
+| ingress.annotations                                                            | `{}`              | Annotations to be added to all ingresses                                            |
+| ingress.ingress                                                                | see `values.yaml` | Ingress resources to be created                                                     |
+| resources.limits                                                               | see `values.yaml` | Limits for the Edge Pod                                                             |
+| resources.requests                                                             | see `values.yaml` | Reserved resources for the Edge Pod                                                 |
+| nodeSelector                                                                   | `{}`              | Node selection for Pod deployment                                                   |
+| tolerations                                                                    | see `values.yaml` | Node tolerations/taints allowed for deploying the Edge Pods                         |
+| extraObjects                                                                   | `{}`              | Ability to add custom Kubernetes objects into this deployment as part of this chart |

--- a/helm-chart-sources/edge/templates/daemonset.yaml
+++ b/helm-chart-sources/edge/templates/daemonset.yaml
@@ -1,0 +1,161 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "common.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+  {{- with .Values.podAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "common.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "common.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.serviceAccount.automountServiceAccountToken }}
+      serviceAccountName: {{ if not .Values.serviceAccount.name }}{{ include "common.fullname" . }}{{ else }}{{ .Values.serviceAccount.name }}{{ end }}
+      {{- end }}
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- if or .Values.extraVolumeMounts .Values.extraConfigmapMounts .Values.extraSecretMounts }}
+      volumes:
+        {{- range .Values.extraVolumeMounts }}
+        - name: {{ .name }}
+          {{- if .existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .existingClaim }}
+          {{- else if .hostPath }}
+          hostPath:
+            path: {{ .hostPath }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
+        {{- range .Values.extraConfigMaps }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+        {{- end }}
+        {{- range .Values.extraSecretMounts }}
+        {{- if .secretName }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+            defaultMode: {{ .defaultMode }}
+        {{- else if .projected }}
+        - name: {{ .name }}
+          projected: {{- toYaml .projected | nindent 12 }}
+        {{- else if .csi }}
+        - name: {{ .name }}
+          csi: {{- toYaml .csi | nindent 12 }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.cribl.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.cribl.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
+          env:
+            - name: CRIBL_DIST_LEADER_URL
+              valueFrom:
+                secretKeyRef:
+                  {{- if ((.Values.cribl).existingSecretForLeader) }}
+                  name: {{ .Values.cribl.existingSecretForLeader }}
+                  {{- else }}
+                  name: {{ include "common.fullname" . }}-cribl-settings
+                  {{- end }}
+                  key: CRIBL_DIST_LEADER_URL
+            - name: CRIBL_HOME
+              value: {{ .Values.cribl.home }}
+            {{- if .Values.cribl.config }}
+            - name: CRIBL_BOOTSTRAP
+              valueFrom:
+                secretKeyRef:
+                  {{- if ((.Values.cribl).existingSecretForConfig) }}
+                  name: {{ .Values.cribl.existingSecretForConfig }}
+                  {{- else }}
+                  name: {{ include "common.fullname" . }}-cribl-settings
+                  {{- end }}
+                  key: CRIBL_BOOTSTRAP
+            {{- end }}
+            {{- range $key, $value := .Values.extraEnv }}
+            - name: {{ tpl $key $ }}
+              value: "{{ tpl (print $value) $ }}"
+            {{- end }}
+            {{- if .Values.envValueFrom }}
+            {{- toYaml .Values.envValueFrom | nindent 12 }}
+            {{- end }}
+            {{- range $key, $value := .Values.env }}
+            - name: {{ tpl $key $ }}
+              value: "{{ tpl (print $value) $ }}"
+            {{- end }}
+          {{- if or .Values.extraConfigMaps .Values.extraSecretMounts .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- range .Values.extraConfigMaps }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath | default "" }}
+              readOnly: {{ .readOnly }}
+            {{- end }}
+            {{- range .Values.extraSecretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath | default "" }}
+              readOnly: {{ .readOnly | default true }}
+            {{- end }}
+            {{- range .Values.extraVolumeMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath | default "" }}
+              subPathExpr: {{ .subPathExpr | default "" }}
+              readOnly: {{ .readOnly }}
+            {{- end }}
+          {{- end }}
+          ports:
+            {{-  range .Values.service.ports }}
+            - name: {{ .name }}
+              containerPort: {{ .port }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm-chart-sources/edge/templates/extras.yaml
+++ b/helm-chart-sources/edge/templates/extras.yaml
@@ -1,0 +1,1 @@
+{{ include "common.extras" . }}

--- a/helm-chart-sources/edge/templates/networking/ingress.yaml
+++ b/helm-chart-sources/edge/templates/networking/ingress.yaml
@@ -1,0 +1,1 @@
+{{- include "common.ingress" . }}

--- a/helm-chart-sources/edge/templates/networking/service.yaml
+++ b/helm-chart-sources/edge/templates/networking/service.yaml
@@ -1,0 +1,30 @@
+{{- if eq .Values.service.enable true }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  {{- range .Values.service.ports }}
+  - port: {{ required "Port is required " .port }}
+    targetPort: {{ coalesce .targetPort .port }}
+    protocol: {{ required "Protocol is required" .protocol }}
+    {{- if .name }}
+    name: {{ .name }}
+    {{- end }}
+  {{- end }}
+  selector:
+    {{- include "common.selectorLabels" . | nindent 4 }}
+  {{- if (and (not (empty .Values.service.loadBalancerIP)) (eq $.Values.service.type "LoadBalancer")) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end -}}
+{{- end -}}

--- a/helm-chart-sources/edge/templates/rbac/clusterrole.yaml
+++ b/helm-chart-sources/edge/templates/rbac/clusterrole.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "common.fullname" . }}:{{ include "common.name" . }}:{{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+  {{- with .Values.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  {{- toYaml .Values.rbac.rules | nindent 2}}
+  {{- range .Values.rbac.extraRules }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/helm-chart-sources/edge/templates/rbac/clusterrolebinding.yaml
+++ b/helm-chart-sources/edge/templates/rbac/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "common.fullname" . }}:{{ include "common.name" . }}:{{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ if not .Values.serviceAccount.name }}{{ include "common.fullname" . }}{{ else }}{{ .Values.serviceAccount.name }}{{ end }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "common.fullname" . }}:{{ include "common.name" . }}:{{ .Release.Namespace }}
+{{- end }}

--- a/helm-chart-sources/edge/templates/rbac/serviceaccount.yaml
+++ b/helm-chart-sources/edge/templates/rbac/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ if not .Values.serviceAccount.name }}{{ include "common.fullname" . }}{{ else }}{{ .Values.serviceAccount.name }}{{ end }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-chart-sources/edge/templates/secret.yaml
+++ b/helm-chart-sources/edge/templates/secret.yaml
@@ -1,0 +1,1 @@
+{{ include "common.secret" . }}

--- a/helm-chart-sources/edge/tests/README.md
+++ b/helm-chart-sources/edge/tests/README.md
@@ -1,0 +1,14 @@
+# Unit Tests for the Cribl Edge Chart
+
+## Prerequisites
+Install the unittest plugin from quintush
+
+```bash
+helm plugin install https://github.com/quintush/helm-unittest
+```
+
+## Run Tests
+```bash
+cd $(git rev-parse --show-toplevel)
+helm unittest -3 helm-chart-sources/edge
+```

--- a/helm-chart-sources/edge/tests/daemonset_test.yaml
+++ b/helm-chart-sources/edge/tests/daemonset_test.yaml
@@ -1,0 +1,48 @@
+suite: DaemonSet
+templates:
+  - daemonset.yaml
+tests:
+  - it: Creates a DaemonSet
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - isAPIVersion:
+          of: apps/v1
+
+  - it: Can define custom repository and tag
+    set:
+      image:
+        repository: foo/bar
+        tag: 42.0.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: foo/bar:42.0.0
+
+  - it: Has a ServiceAccount
+    release:
+      name: foo
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: foo-edge
+
+  - it: Sets the default CRIBL_DIST_LEADER_URL
+    set:
+      cribl.leader: foo
+    release:
+      name: foo
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: foo-edge-cribl-settings
+
+  - it: Sets the custom CRIBL_DIST_LEADER_URL
+    set:
+      cribl.existingSecretForLeader: foo
+    release:
+      name: foo
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: foo

--- a/helm-chart-sources/edge/tests/ingress_test.yaml
+++ b/helm-chart-sources/edge/tests/ingress_test.yaml
@@ -1,0 +1,28 @@
+suite: Ingress
+templates:
+  - networking/ingress.yaml
+tests:
+  - it: Doesn't create an Ingress by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Creates a single Ingress
+    set:
+      ingress:
+        enable: true
+        ingress:
+          - name: ingress-example
+            rules:
+              - host: foo
+                paths:
+                  - path: /
+                    port: 9420
+    release:
+      name: abc
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: abc-edge

--- a/helm-chart-sources/edge/tests/rbac_test.yaml
+++ b/helm-chart-sources/edge/tests/rbac_test.yaml
@@ -1,0 +1,54 @@
+suite: RBAC
+templates:
+  - rbac/serviceaccount.yaml
+  - rbac/clusterrole.yaml
+tests:
+  - it: Creates a ServiceAccount
+    template: rbac/serviceaccount.yaml
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - isAPIVersion:
+          of: v1
+
+  - it: Doesn't create a ServiceAccount
+    set:
+      serviceAccount.create: false
+    template: rbac/serviceaccount.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Adds annotations to the ServiceAccount
+    set:
+      serviceAccount.annotations:
+        foo: first
+        bar: second
+    template: rbac/serviceaccount.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            foo: first
+            bar: second
+
+  - it: Creates a ClusterRole
+    template: rbac/clusterrole.yaml
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - isAPIVersion:
+          of: rbac.authorization.k8s.io/v1
+
+  - it: Defines ClusterRole Rules (defaults)
+    template: rbac/clusterrole.yaml
+    asserts:
+      - contains:
+          path: rules
+          any: true
+          content:
+            resources:
+              - daemonsets
+              - deployments
+              - replicasets
+              - statefulsets

--- a/helm-chart-sources/edge/tests/secret_test.yaml
+++ b/helm-chart-sources/edge/tests/secret_test.yaml
@@ -1,0 +1,51 @@
+suite: Secret
+templates:
+  - secret.yaml
+  - daemonset.yaml
+tests:
+  - it: Sets CRIBL_DIST_LEADER_URL from cribl.leader
+    set:
+      cribl.leader: tcp://fake@example:4200?group=foo
+    template: secret.yaml
+    asserts:
+      - equal:
+          path: stringData.CRIBL_DIST_LEADER_URL
+          value: tcp://fake@example:4200?group=foo
+      - isNull:
+          path: stringData.CRIBL_BOOTSTRAP
+
+  - it: Sets CRIBL_BOOTSTRAP from cribl.config
+    set:
+      cribl:
+        leader: tcp://fake@example:4200?group=foo
+        config: foo
+    template: secret.yaml
+    asserts:
+      - equal:
+          path: stringData.CRIBL_DIST_LEADER_URL
+          value: tcp://fake@example:4200?group=foo
+      - equal:
+          path: stringData.CRIBL_BOOTSTRAP
+          value: foo
+            
+  - it: Sets the correct CRIBL_DIST_LEADER_URL in the DaemonSet to the default
+    template: daemonset.yaml
+    set:
+      cribl.leader: leader
+    release:
+      name: abc
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: abc-edge-cribl-settings
+
+  - it: Sets the CRIBL_DIST_LEADER_URL env to the existing secret value
+    template: daemonset.yaml
+    set:
+      cribl.existingSecretForLeader: sup3rsecr3t
+    release:
+      name: abc
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: sup3rsecr3t

--- a/helm-chart-sources/edge/tests/service_test.yaml
+++ b/helm-chart-sources/edge/tests/service_test.yaml
@@ -1,0 +1,78 @@
+suite: Service
+templates:
+  - networking/service.yaml
+tests:
+  - it: Doesn't create a Service by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Creates a service with the default port
+    set:
+      service.enable: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports
+          value:
+            - port: 9420
+              targetPort: 9420
+              protocol: TCP
+              name: edge-api
+      - isNull:
+          path: spec.loadBalancerIP
+
+  - it: Uses custom ports
+    set:
+      service:
+        enable: true
+        type: LoadBalancer
+        ports:
+          - port: 9999
+            targetPort: 9998
+            protocol: TCP
+          - port: 10000
+            protocol: TCP
+            name: foo
+        loadBalancerIP: 1.2.3.4
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.ports
+          value:
+            - port: 9999
+              targetPort: 9998
+              protocol: TCP
+            - port: 10000
+              targetPort: 10000
+              protocol: TCP
+              name: foo
+      - equal:
+          path: spec.loadBalancerIP
+          value: 1.2.3.4
+
+  - it: Should not set loadBalancerIP if type is ClusterIP
+    set:
+      service:
+        enable: true
+        type: ClusterIP # redundant
+        loadBalancerIP: 1.2.3.4
+    assert:
+      - isNull:
+          path: spec.loadBalancerIP
+
+  - it: Should use the externalTrafficPolicy
+    set:
+      service:
+        enable: true
+        externalTrafficPolicy: Local
+    assert:
+      - equal:
+          path: spec.externalTrafficPolicy
+          value: Local

--- a/helm-chart-sources/edge/values.yaml
+++ b/helm-chart-sources/edge/values.yaml
@@ -1,0 +1,240 @@
+# Cribl Edge Helm Chart Values
+
+image:
+  repository: cribl/cribl
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: 4.0.0
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# Default environment variables for Cribl Edge Deployment
+env:
+  CRIBL_DIST_MODE: managed-edge
+  CRIBL_EDGE: 1
+# Downward API values
+envValueFrom:
+  - name: CRIBL_K8S_POD
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+# Extra environment variables
+extraEnv: []
+# Extra environment variables (from Secrets)
+extraEnvFrom: []
+# Extra ConfigMaps
+extraConfigMaps: []
+# Extra Secrets
+extraSecretMounts: []
+# Extra Volume mounts
+extraVolumeMounts:
+  # This is needed to report Docker container info.
+  # Only Docker is supported today, containerd coming soon
+  - name: docker-sock
+    mountPath: /var/run/docker.sock
+    hostPath: /var/run/docker.sock
+  # This is needed to access host processes and metrics.
+  - name: host-root
+    mountPath: /hostfs
+    hostPath: /
+    readonly: true
+# Extra containers
+extraContainers: []
+# Extra init containers
+extraInitContainers: []
+# Additional Pod labels
+labels: {}
+
+cribl:
+  home: /opt/cribl
+  # if set, overrides cribl.leader value
+  existingSecretForLeader:
+  # CRIBL_DIST_MASTER_URL
+  leader:
+  # Bootstrap config
+  existingSecretForConfig:
+  config:
+  # cribl/local.yml:
+  #  foo: bar
+  readinessProbe:
+    httpGet:
+      path: /api/v1/health
+      port: 9420
+      scheme: HTTP
+    initialDelaySeconds: 15
+    timeoutSeconds: 1
+  livenessProbe:
+    httpGet:
+      path: /api/v1/health
+      port: 9420
+      scheme: HTTP
+    initialDelaySeconds: 15
+    timeoutSeconds: 1
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  # If create is false, and name is set, the DaemonSet attempts to use this name as the serviceAccountName
+  name: ""
+  automountServiceAccountToken: true
+
+# Cluster Roles
+rbac:
+  create: true
+  annotations: {}
+  rules:
+    - apiGroups:
+        - ""
+      resources:
+        - configmaps
+        - endpoints
+        - limitranges
+        - namespaces
+        - nodes
+        - persistentvolumeclaims
+        - pods
+        - replicationcontrollers
+        - secrets
+        - services
+        - strategicMergePatches
+        - nodes/log
+        - nodes/metrics
+        - nodes/proxy
+        - nodes/spec
+        - nodes/stats
+      verbs: ['get', 'list', 'watch']
+    - apiGroups:
+        - "apps"
+      resources:
+        - daemonsets
+        - deployments
+        - replicasets
+        - statefulsets
+      verbs: ['get', 'list', 'watch']
+    - apiGroups:
+        - "batch"
+      resources:
+        - cronjobs
+        - jobs
+      verbs: ['get', 'list', 'watch']
+    - apiGroups:
+        - "autoscaling"
+      resources:
+        - horizontalpodautoscalers
+      verbs: ['get', 'list', 'watch']
+    - apiGroups:
+        - "policy"
+      resources:
+        - poddisruptionbudgets
+      verbs: ['get', 'list', 'watch']
+    - apiGroups:
+        - "networking.k8s.io"
+      resources:
+        - ingresses
+        - networkpolicies
+      verbs: ['get', 'list', 'watch']
+    - apiGroups:
+        - "admissionregistration.k8s.io"
+      resources:
+        - mutatingwebhookconfigurations
+        - validatingwebhookconfigurations
+      verbs: ['get', 'list', 'watch']
+    - apiGroups:
+        - "certificates.k8s.io"
+      resources:
+        - certificatesigningrequests
+      verbs: ['get', 'list', 'watch']
+    - apiGroups:
+        - "storage.k8s.io"
+      resources:
+        - storageclasses
+        - volumeattachments
+      verbs: ['get', 'list', 'watch']
+  extraRules: []
+  # - apiGroups: []
+  #   resources: []
+  #   resourceNames: []
+  #   verbs: []
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # privileged: true
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# Cribl Edge in K8s does not require a Service
+# It is recommended to use a Worker Group deployment for receiving logs from network sources.
+service:
+  enable: false
+  type: ClusterIP
+  externalTrafficPolicy: Cluster
+  annotations: {}
+  ports:
+    - name: edge-api
+      port: 9420
+      protocol: TCP
+
+ingress:
+  enable: false
+  className: ""
+#  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+#  ingress:
+#    - name: ingress-example
+#      # TLS secrets for this ingress
+#      tls: {}
+#      # Override the ingressClassName for this ingress
+#      ingressClassName:
+#      # Annotation overrides (merged with defaults)
+#      annotations: {}
+#      # Array of Ingress rules
+#      # https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
+#      rules:
+#        - host: ingress.example.com
+#          paths:
+#            - path: /*
+#              port: 8088
+#        - host: ingress2.example.com
+#          paths:
+#            - path: /exact/path/matching
+#              # Other path kinds can be specified (default is Prefix)
+#              # https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+#              kind: Exact
+#              port: 8080
+#            - path: /*
+#              port: 8082
+#        # Example default rule without host name
+#        - paths:
+#            - path: /*
+#              port: 8088
+
+resources:
+  limits:
+   cpu: 2
+   memory: 4096Mi
+  requests:
+   cpu: .25
+   memory: 1024Mi
+
+nodeSelector: {}
+
+# By default, allow scheduling DaemonSet on any Node in the Cluster
+tolerations:
+  - operator: Exists
+
+extraObjects: {}

--- a/helm-chart-sources/logstream-leader/Chart.yaml
+++ b/helm-chart-sources/logstream-leader/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.5.4
+version: 4.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.5.4
+appVersion: 4.0.0

--- a/helm-chart-sources/logstream-leader/README.md
+++ b/helm-chart-sources/logstream-leader/README.md
@@ -11,7 +11,7 @@ If you're migrating from the deprecated `logstream‑master` chart, please see t
 
 # New Capabilities
 
-* Support for the 3.5.4 version of Cribl Stream (default version)
+* Support for the 4.0.0 version of Cribl Stream (default version)
 
 # Deployment
 

--- a/helm-chart-sources/logstream-leader/values.yaml
+++ b/helm-chart-sources/logstream-leader/values.yaml
@@ -9,7 +9,7 @@ criblImage:
   repository: cribl/cribl
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 3.5.4
+  tag: 4.0.0
 
 imagePullSecrets: []
 nameOverride: "leader"

--- a/helm-chart-sources/logstream-workergroup/Chart.yaml
+++ b/helm-chart-sources/logstream-workergroup/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.5.4
+version: 4.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.5.4
+appVersion: 4.0.0

--- a/helm-chart-sources/logstream-workergroup/README.md
+++ b/helm-chart-sources/logstream-workergroup/README.md
@@ -8,7 +8,7 @@ This chart deploys a Cribl Stream worker group.
 Versions starting with 3.4.0 include a change to the syntax for RBAC values. Before you upgrade the chart from pre-3.4.0 versions, please see the [table below](#values) for current options for the `rbac.apiGroups`, `rbac.verbs`, and `rbac.resources` values.
 
 # New Capabilities
-* Support for the 3.5.4 version of Cribl Stream (default version)
+* Support for the 4.0.0 version of Cribl Stream (default version)
 
 # Deployment
 

--- a/helm-chart-sources/logstream-workergroup/values.yaml
+++ b/helm-chart-sources/logstream-workergroup/values.yaml
@@ -19,7 +19,7 @@ criblImage:
   repository: cribl/cribl
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 3.5.4
+  tag: 4.0.0
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
* Begin refactoring charts from WET to DRY (see Common chart for reusable resources)
* New Edge chart for deploying Cribl Edge in Kubernetes clusters focused on the Logs and Metrics sources for Kubernetes

Note for testers: clone the entire branch and then modify `edge/Chart.yaml` to read as follows:

```
...
repository: file://../common
```

Run: `helm dependencies update`

This is only required before the initial release/publishing of the common chart.