### PR TITLE
Update patterns to bump edge sources too

### DIFF
--- a/.github/scripts/bump-version
+++ b/.github/scripts/bump-version
@@ -15,9 +15,10 @@ fi
 echo Bumping helm-charts default Cribl version to $tag
 git stash
 
-perl -i -pe "s/^(?:appVersion|version): \K[\d\.]+/$tag/" helm-chart-sources/logstream-{leader,workergroup}/Chart.yaml
-perl -i -pe "s/^\s+tag: \K[\d\.]+/$tag/" helm-chart-sources/logstream-{leader,workergroup}/values.yaml
-perl -i -pe "s/Support for the \K[\d\.]+/$tag/" helm-chart-sources/logstream-{leader,workergroup}/README.md
+perl -i -pe "s/^(?:appVersion|version): \K[\d\.]+/$tag/" helm-chart-sources/{logstream-{leader,workergroup},edge}/Chart.yaml
+perl -i -pe "s/^\s+tag: \K[\d\.]+/$tag/" helm-chart-sources/{logstream-{leader,workergroup},edge}/values.yaml
+perl -i -pe "s/Support for the \K[\d\.]+/$tag/" helm-chart-sources/{logstream-{leader,workergroup},edge}/README.md
+perl -i -pe "s/^\W image.tag\W+\K[\d\.]+/$tag/" helm-chart-sources/{logstream-{leader,workergroup},edge}/README.md
 
 git commit -am "Bump version to $tag"
 git tag -am "Released version $tag" v$tag

--- a/helm-chart-sources/edge/Chart.yaml
+++ b/helm-chart-sources/edge/Chart.yaml
@@ -3,7 +3,7 @@ name: edge
 description: A Helm chart for Kubernetes
 type: application
 version: 4.0.0
-appVersion: "4.0.0"
+appVersion: 4.0.0
 icon: https://criblio.github.io/helm-charts/images/Cribl_Logo_Color_TM.png
 
 #dependencies:

--- a/helm-chart-sources/edge/README.md
+++ b/helm-chart-sources/edge/README.md
@@ -38,7 +38,7 @@ This section covers the most likely values to override. To see the full scope of
 |--------------------------------------------------------------------------------|-------------------|-------------------------------------------------------------------------------------|
 | image.repository                                                               | `cribl/cribl`     | Docker image repository to pull images                                              |
 | image.pullPolicy                                                               | `Always`          | When will the Node pull the image                                                   |
-| image.tag                                                                      | `3.5.4`           | The Version of Cribl to deploy                                                      |
+| image.tag                                                                      | `4.0.0`           | The Version of Cribl to deploy                                                      |
 | imagePullSecrets                                                               | `[]`              | Credentials to pull container images                                                |
 | nameOverride                                                                   |                   | Overrides the chart name                                                            |
 | fullNameOverride                                                               |                   | Overrides the Helm deployment name                                                  |


### PR DESCRIPTION
So next time, running `.github/scripts/bump-version 4.0.1` will take care of everything