### PR TITLE
Add config.tags to worker chart

### DIFF
--- a/helm-chart-sources/logstream-workergroup/templates/secret.yaml
+++ b/helm-chart-sources/logstream-workergroup/templates/secret.yaml
@@ -37,7 +37,7 @@ stringData:
     {{- $group = .Values.config.group }}
   {{- end }}
   {{- $tagopts := "" }}
-  {{- range $tag := .Values.config.tags }}
-    {{- $tagopts = printf "%s&tag=%s" $tagopts .tag }}
+  {{- range .Values.config.tags }}
+    {{- $tagopts = printf "%s&tag=%s" $tagopts . }}
   {{- end }}
   url-master: "{{ $proto }}://{{ .Values.config.token }}@{{ .Values.config.host }}:4200?group={{ $group }}&tag={{ $group }}{{ $tlsopts | replace " " "+"}}{{ $tagopts | replace " " "+" }}"

--- a/helm-chart-sources/logstream-workergroup/templates/secret.yml
+++ b/helm-chart-sources/logstream-workergroup/templates/secret.yml
@@ -36,4 +36,8 @@ stringData:
   {{- else if .Values.config.group }}
     {{- $group = .Values.config.group }}
   {{- end }}
-  url-master: "{{ $proto }}://{{ .Values.config.token }}@{{ .Values.config.host }}:4200?group={{ $group }}&tag={{ $group }}{{ $tlsopts | replace " " "+"}}"
+  {{- $tagopts := "" }}
+  {{- range $tag := .Values.config.tags }}
+    {{- $tagopts = printf "%s&tag=%s" $tagopts .tag }}
+  {{- end }}
+  url-master: "{{ $proto }}://{{ .Values.config.token }}@{{ .Values.config.host }}:4200?group={{ $group }}&tag={{ $group }}{{ $tlsopts | replace " " "+"}}{{ $tagopts | replace " " "+" }}"

--- a/helm-chart-sources/logstream-workergroup/tests/secret_test.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/secret_test.yaml
@@ -1,0 +1,29 @@
+suite: Secret
+templates:
+  - secret.yaml
+tests:
+  - it: Should set a secret
+    set:
+      config:
+        token: foo-bar-baz
+        host: supreme-leader
+        group: goats
+    asserts:
+      - equal:
+          path: stringData.url-master
+          value: "tcp://foo-bar-baz@supreme-leader:4200?group=goats&tag=goats"
+
+  - it: Should set multiple tags
+    set:
+      config:
+        token: foo-bar-baz
+        host: supreme-leader
+        group: goats
+        tags:
+          - foo
+          - bar
+          - baz
+    asserts:
+      - equal:
+          path: stringData.url-master
+          value: "tcp://foo-bar-baz@supreme-leader:4200?group=goats&tag=goats&tag=foo&tag=bar&tag=baz"

--- a/helm-chart-sources/logstream-workergroup/values.yaml
+++ b/helm-chart-sources/logstream-workergroup/values.yaml
@@ -33,6 +33,7 @@ config:
   probes: true
   tlsLeader:
     enable: false
+  tags: []
 
 deployment: deployment
 


### PR DESCRIPTION
This adds a `config.tags` array value that gets translated into additional `&tag=foo` query parameters in the URL used for connection to the Leader. We already send the group name as a tag for backward compatability reasons. This allows the user to add more tags.