### PR TITLE
Use kebabcase to format HPA name correctly

### DIFF
--- a/helm-chart-sources/logstream-workergroup/templates/hpa.yaml
+++ b/helm-chart-sources/logstream-workergroup/templates/hpa.yaml
@@ -7,9 +7,9 @@ apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   {{- if .Values.config.group }}
-  name: {{ include "logstream-workergroup.fullname" . }}-{{ .Values.config.group }}
+  name: {{ include "logstream-workergroup.fullname" . }}-{{ (kebabcase .Values.config.group) }}
   {{- else if .Values.config.tag }}
-  name: {{ include "logstream-workergroup.fullname" . }}-{{ .Values.config.tag }}
+  name: {{ include "logstream-workergroup.fullname" . }}-{{ (kebabcase .Values.config.tag) }}
   {{- end }}
 
   labels:

--- a/helm-chart-sources/logstream-workergroup/tests/hpa_test.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/hpa_test.yaml
@@ -1,0 +1,25 @@
+suite: Secret
+templates:
+  - hpa.yaml
+tests:
+  - it: Should name with default
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-logstream-workergroup-kubernetes
+
+  - it: Should kebab-case non-RFC 1123 compliant names from camelCase
+    set:
+      config.group: "defaultHybrid"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-logstream-workergroup-default-hybrid
+
+  - it: Should kebab-case non-RFC 1123 compliant names from underscores
+    set:
+      config.group: "g_o_a_t"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-logstream-workergroup-g-o-a-t


### PR DESCRIPTION
Chart does not deploy correctly with HPA enabled using a group name such as `defaultHybrid`. 

The [kebab-case](https://helm.sh/docs/chart_template_guide/function_list/#kebabcase) takes care of fixing this automatically.

Fixes #91 