### PR TITLE
Fix use of extraEnvFrom

### DIFF
--- a/helm-chart-sources/edge/templates/daemonset.yaml
+++ b/helm-chart-sources/edge/templates/daemonset.yaml
@@ -121,7 +121,7 @@ spec:
               value: "{{ tpl (print $value) $ }}"
             {{- end }}
             {{- if .Values.extraEnvFrom }}
-            {{- toYaml .Values.envValueFrom | nindent 12 }}
+            {{- toYaml .Values.extraEnvFrom | nindent 12 }}
             {{- end }}
             {{- if .Values.envValueFrom }}
             {{- toYaml .Values.envValueFrom | nindent 12 }}


### PR DESCRIPTION
If set, it was still using the envFrom values, instead of the extraEnvFrom values