### PR TITLE
Remove resourcename scope-secret in AppScope chart

### DIFF
--- a/helm-chart-sources/appscope/templates/webhook-cert-cluster-rbac.yaml
+++ b/helm-chart-sources/appscope/templates/webhook-cert-cluster-rbac.yaml
@@ -27,8 +27,6 @@ rules:
   - ""
   resources:
   - secrets
-  resourceNames: 
-    - "scope-secret"
   verbs:  ['create', 'get', 'patch']
 - apiGroups:
   - ""


### PR DESCRIPTION
- fix regression introduced in baa8bec
- this commit allows pod `appscope-webhook-cert-setup` to complete
- `scope-secret` is created by `webhook-cert-manager` itself [1]

Ref:
[1] https://github.com/criblio/k8s-webhook-cert-manager/blob/6e993f86e95dfa55f6da4926445a17bf03f6a0e1/generate_certificate.sh#L174-L181