### PR TITLE
add proto option for container port

### DIFF
--- a/helm-chart-sources/logstream-leader/templates/_pod.tpl
+++ b/helm-chart-sources/logstream-leader/templates/_pod.tpl
@@ -52,6 +52,7 @@ containers:
       {{-  range .Values.service.ports }}
       - name: {{ .name }}
         containerPort: {{ .port }}
+        protocol: {{ .protocol | default "TCP" }}
       {{- end }}
     {{- if .Values.config.probes }}
     {{- with .Values.config.livenessProbe }}


### PR DESCRIPTION
Update the `_pod.tpl` helper to respect `protocol` so other services that leverage UDP can be exposed on the pod.