### PR TITLE
Add nodeSelector to default values for Stream workers

### DIFF
--- a/helm-chart-sources/logstream-workergroup/values.yaml
+++ b/helm-chart-sources/logstream-workergroup/values.yaml
@@ -57,6 +57,7 @@ deployment: deployment
 
 podAnnotations: {}
 
+nodeSelector: {}
 # tolerations: []
 
 #extraPodConfigs:


### PR DESCRIPTION
This threw me off. I didnt see a `nodeSelector`defined in the default values but it is supported in `_pod.tpl`. Hopefully save someone a few clicks to see if we support it