### PR TITLE
Fix git ownership issues on leader config volume

### DIFF
--- a/helm-chart-sources/logstream-leader/templates/_pod.tpl
+++ b/helm-chart-sources/logstream-leader/templates/_pod.tpl
@@ -75,7 +75,7 @@ containers:
     {{- end }}
     {{- end }}
     resources:
-      {{- toYaml .Values.resources | nindent 12 }}
+      {{- toYaml .Values.resources | nindent 6 }}
     env:
       # Self-Signed Certs
       - name: NODE_TLS_REJECT_UNAUTHORIZED
@@ -111,7 +111,6 @@ containers:
         value: "if [ ! -e $CRIBL_VOLUME_DIR/local/cribl/mappings.yml ]; then mkdir -p $CRIBL_VOLUME_DIR/local/cribl;  cp /var/tmp/config_bits/groups.yml $CRIBL_VOLUME_DIR/local/cribl/groups.yml; cp /var/tmp/config_bits/mappings.yml $CRIBL_VOLUME_DIR/local/cribl/mappings.yml; fi"
         {{- $b_iter = add $b_iter 1 }}
       {{- end }}
-
      {{- $a_iter := 1 -}} 
      {{- if .Values.config.adminPassword }}
       - name: CRIBL_AFTER_START_CMD_{{ $a_iter }}
@@ -121,10 +120,10 @@ containers:
 {{- with .Values.extraContainers }}
   {{- toYaml . | nindent 2 }}
 {{- end }}
-
+{{- if or .Values.extraInitContainers .Values.consolidate_volumes }}
 initContainers:
 {{- with .Values.extraInitContainers }}
-  {{- toYaml . | nindent 8 }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- if  (and .Release.IsUpgrade .Values.consolidate_volumes)  }}
   - name: pre-upgrade-volume-coalescence
@@ -148,10 +147,6 @@ initContainers:
       - name: groups-storage
         mountPath: {{ .Values.config.criblHome }}/group
 {{- end }}
-
-{{- with .Values.nodeSelector }}
-nodeSelector:
-  {{- toYaml .  | nindent 2 }}
 {{- end }}
 volumes:
   {{- if  or .Values.config.license ( or .Values.config.adminPassword .Values.config.groups ) }}
@@ -215,18 +210,16 @@ volumes:
     csi: {{- toYaml .csi | nindent 6 }}
 {{- end }}
 {{- end }}
-
-
 {{- with .Values.nodeSelector }}
 nodeSelector:
-  {{- toYaml . | nindent 8 }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- with .Values.affinity }}
 affinity:
-  {{- toYaml . | nindent 8 }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- with .Values.tolerations }}
 tolerations:
-  {{- toYaml . | nindent 8 }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/helm-chart-sources/logstream-leader/templates/_pod.tpl
+++ b/helm-chart-sources/logstream-leader/templates/_pod.tpl
@@ -9,7 +9,7 @@ securityContext:
 {{- if or (eq $key "runAsUser") (eq $key "runAsGroup") (eq $key "fsGroup")}}
   {{ $key }}: {{ $value | int }}
 {{- else }}
-  {{ $key }}: {{ $value | int }}
+  {{ $key }}: {{ $value }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -23,7 +23,7 @@ containers:
     {{- if or (eq $key "runAsUser") (eq $key "runAsGroup") (eq $key "fsGroup")}}
       {{ $key }}: {{ $value | int }}
     {{- else }}
-      {{ $key }}: {{ $value | int }}
+      {{ $key }}: {{ $value }}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/helm-chart-sources/logstream-leader/templates/claims.yaml
+++ b/helm-chart-sources/logstream-leader/templates/claims.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  {{ if .Values.config.scName }}
+  {{- if .Values.config.scName }}
   storageClassName:   {{ .Values.config.scName }}
-  {{- end}}
+  {{- end }}
   resources:
     requests:
       storage: 20Gi

--- a/helm-chart-sources/logstream-leader/templates/configmap.yaml
+++ b/helm-chart-sources/logstream-leader/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if or .Values.podSecurityContext .Values.securityContext }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "logstream-leader.fullname" . }}-gitconfig
+  labels:
+    {{- include "logstream-leader.labels" . | nindent 4 }}
+data:
+  .gitconfig: |
+    [safe]
+    directory = {{ .Values.config.criblHome }}/config-volume
+{{- end }}

--- a/helm-chart-sources/logstream-leader/templates/extras.yaml
+++ b/helm-chart-sources/logstream-leader/templates/extras.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraObjects }}
+---
+{{- if typeIs "string" . }}
+  {{ . | nindent 0 }}
+{{- else }}
+  {{- toYaml . | nindent 0 }}
+{{- end }}
+{{- end }}

--- a/helm-chart-sources/logstream-leader/tests/configmap_test.yaml
+++ b/helm-chart-sources/logstream-leader/tests/configmap_test.yaml
@@ -1,0 +1,19 @@
+suite: ConfigMap
+templates:
+  - configmap.yaml
+tests:
+  - it: Should not exist by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a configmap
+    set:
+      securityContext:
+        runAsUser: 1000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1

--- a/helm-chart-sources/logstream-leader/tests/extras_test.yaml
+++ b/helm-chart-sources/logstream-leader/tests/extras_test.yaml
@@ -1,0 +1,50 @@
+suite: Extras
+templates:
+  - extras.yaml
+tests:
+  - it: Creates something extra
+    template: extras.yaml
+
+    set:
+      extraObjects:
+        - |
+          kind: Foo
+          fake2: true
+          apiVersion: cribl.io/v1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Foo
+      - equal:
+          path: fake2
+          value: true
+      - isAPIVersion:
+          of: cribl.io/v1
+
+  - it: Creates from object
+    template: extras.yaml
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: Pod
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: foo
+          fake: 1234
+    asserts:
+      - hasDocuments:
+          count: 2
+      - containsDocument:
+          apiVersion: v1
+          kind: Pod
+      - equal:
+          path: metadata.name
+          value: foo
+        documentIndex: 1
+      - equal:
+          path: fake
+          value: 1234
+        documentIndex: 1

--- a/helm-chart-sources/logstream-leader/tests/fixtures/generic.yaml
+++ b/helm-chart-sources/logstream-leader/tests/fixtures/generic.yaml
@@ -1,0 +1,2 @@
+config:
+  token: criblmaster

--- a/helm-chart-sources/logstream-leader/tests/fixtures/nodeSelector.yaml
+++ b/helm-chart-sources/logstream-leader/tests/fixtures/nodeSelector.yaml
@@ -1,0 +1,2 @@
+nodeSelector:
+  kubernetes.io/os: linux

--- a/helm-chart-sources/logstream-leader/tests/fixtures/securityContext.yaml
+++ b/helm-chart-sources/logstream-leader/tests/fixtures/securityContext.yaml
@@ -1,0 +1,7 @@
+securityContext:
+  runAsUser: 1000620000
+  runAsGroup: 1000620000
+
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000

--- a/helm-chart-sources/logstream-leader/tests/fixtures/securityContext.yaml
+++ b/helm-chart-sources/logstream-leader/tests/fixtures/securityContext.yaml
@@ -1,7 +1,11 @@
 securityContext:
   runAsUser: 1000620000
   runAsGroup: 1000620000
+  fsGroupChangePolicy: Always
+  runAsNonRoot: true
 
 podSecurityContext:
   runAsUser: 1000
   runAsGroup: 1000
+  fsGroupChangePolicy: Always
+  runAsNonRoot: true

--- a/helm-chart-sources/logstream-leader/tests/securitycontext_test.yaml
+++ b/helm-chart-sources/logstream-leader/tests/securitycontext_test.yaml
@@ -10,25 +10,39 @@ tests:
   - it: Should set correct command
     set:
       securityContext:
-        runAsGroup: "1000"
-        runAsUser: "1000"
+        runAsGroup: 1000
+        runAsUser: 1000
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].command
+          path: spec.template.spec.containers[0].securityContext
           value:
-            - bash
-            - -c
-            - "set -x \napt update; apt-get install -y gosu\nuseradd -d /opt/cribl -g \"1000\" -u \"1000\" cribl\nchown  -R   \"1000:1000\" /opt/cribl\ngosu \"1000:1000\" /sbin/entrypoint.sh cribl\n"
+            runAsGroup: 1000
+            runAsUser: 1000
 
   - it: Should handle big numbers
     set:
       securityContext:
-        runAsGroup: "1000620000"
-        runAsUser: "1000620000"
+        runAsGroup: 1000620000
+        runAsUser: 1000620000
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].command
+          path: spec.template.spec.containers[0].securityContext
           value:
-            - bash
-            - -c
-            - "set -x \napt update; apt-get install -y gosu\nuseradd -d /opt/cribl -g \"1000620000\" -u \"1000620000\" cribl\nchown  -R   \"1000620000:1000620000\" /opt/cribl\ngosu \"1000620000:1000620000\" /sbin/entrypoint.sh cribl\n"
+            runAsGroup: 1000620000
+            runAsUser: 1000620000
+
+  - it: should set the gitconfig mounts
+    set:
+      securityContext:
+        runAsUser: 1000
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0].volumeMounts[1]
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: gitconfig
+      - isNotNull:
+          path: spec.template.spec.volumes[1]
+      - equal:
+          path: spec.template.spec.volumes[1].name
+          value: gitconfig

--- a/helm-chart-sources/logstream-leader/values.yaml
+++ b/helm-chart-sources/logstream-leader/values.yaml
@@ -99,6 +99,9 @@ tolerations: []
 
 affinity: {}
 
+# Extra manifests to be deployed
+extraObjects: {}
+
 # Applies extra labels to all resources deployed with this chart
 extraLabels: {}
 # key: value

--- a/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
+++ b/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
@@ -20,7 +20,7 @@ securityContext:
 {{- if or (eq $key "runAsUser") (eq $key "runAsGroup") (eq $key "fsGroup")}}
   {{ $key }}: {{ $value | int }}
 {{- else }}
-  {{ $key }}: {{ $value | int }}
+  {{ $key }}: {{ $value }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -34,7 +34,7 @@ containers:
     {{- if or (eq $key "runAsUser") (eq $key "runAsGroup") (eq $key "fsGroup")}}
       {{ $key }}: {{ $value | int }}
     {{- else }}
-      {{ $key }}: {{ $value | int }}
+      {{ $key }}: {{ $value }}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
+++ b/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
@@ -14,20 +14,29 @@ initContainers:
 {{- if .Values.config.hostNetwork }}
 hostNetwork: true
 {{- end }}
+{{- if .Values.podSecurityContext }}
+securityContext:
+{{- range $key, $value := .Values.podSecurityContext }}
+{{- if or (eq $key "runAsUser") (eq $key "runAsGroup") (eq $key "fsGroup")}}
+  {{ $key }}: {{ $value | int }}
+{{- else }}
+  {{ $key }}: {{ $value | int }}
+{{- end }}
+{{- end }}
+{{- end }}
 containers:
   - name: {{ .Chart.Name }}
     image: "{{ .Values.criblImage.repository }}:{{ .Values.criblImage.tag | default .Chart.AppVersion }}"
     imagePullPolicy: {{ .Values.criblImage.pullPolicy }}
     {{- if .Values.securityContext }}
-    command: 
-    - bash
-    - -c 
-    - |
-      set -x 
-      apt update; apt-get install -y gosu
-      useradd -d /opt/cribl -g "{{- .Values.securityContext.runAsGroup }}" -u "{{- .Values.securityContext.runAsUser }}" cribl
-      chown  -R   "{{- .Values.securityContext.runAsUser }}:{{- .Values.securityContext.runAsGroup }}" /opt/cribl
-      gosu "{{- .Values.securityContext.runAsUser }}:{{- .Values.securityContext.runAsGroup }}" /sbin/entrypoint.sh cribl
+    securityContext:
+    {{- range $key, $value := .Values.securityContext }}
+    {{- if or (eq $key "runAsUser") (eq $key "runAsGroup") (eq $key "fsGroup")}}
+      {{ $key }}: {{ $value | int }}
+    {{- else }}
+      {{ $key }}: {{ $value | int }}
+    {{- end }}
+    {{- end }}
     {{- end }}
     {{- if .Values.config.probes }}
     {{- with .Values.config.livenessProbe }}

--- a/helm-chart-sources/logstream-workergroup/templates/extras.yaml
+++ b/helm-chart-sources/logstream-workergroup/templates/extras.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraObjects }}
+---
+{{- if typeIs "string" . }}
+  {{ . | nindent 0 }}
+{{- else }}
+  {{- toYaml . | nindent 0 }}
+{{- end }}
+{{- end }}

--- a/helm-chart-sources/logstream-workergroup/tests/extras_test.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/extras_test.yaml
@@ -1,0 +1,50 @@
+suite: Extras
+templates:
+  - extras.yaml
+tests:
+  - it: Creates something extra
+    template: extras.yaml
+
+    set:
+      extraObjects:
+        - |
+          kind: Foo
+          fake2: true
+          apiVersion: cribl.io/v1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Foo
+      - equal:
+          path: fake2
+          value: true
+      - isAPIVersion:
+          of: cribl.io/v1
+
+  - it: Creates from object
+    template: extras.yaml
+    set:
+      extraObjects:
+        - apiVersion: v1
+          kind: Pod
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: foo
+          fake: 1234
+    asserts:
+      - hasDocuments:
+          count: 2
+      - containsDocument:
+          apiVersion: v1
+          kind: Pod
+      - equal:
+          path: metadata.name
+          value: foo
+        documentIndex: 1
+      - equal:
+          path: fake
+          value: 1234
+        documentIndex: 1

--- a/helm-chart-sources/logstream-workergroup/tests/fixtures/securityContext.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/fixtures/securityContext.yaml
@@ -1,0 +1,7 @@
+securityContext:
+  runAsUser: 1000620000
+  runAsGroup: 1000620000
+
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000

--- a/helm-chart-sources/logstream-workergroup/values.yaml
+++ b/helm-chart-sources/logstream-workergroup/values.yaml
@@ -186,6 +186,9 @@ ingress:
 #            - path: /*
 #              port: 8088
 
+# Extra manifests to be deployed
+extraObjects: {}
+
 # Applies extra labels to all resources deployed with this chart
 extraLabels: {}
 # key: value


### PR DESCRIPTION
Deploys a ConfigMap resource that is mounted to `/.gitconfig` which defines the safe path:

```
[safe]
directory = /opt/cribl/config-volume
```

this is to resolve the error:

> Error: fatal: detected dubious ownership in repository at '/opt/cribl/config-volume'

Resolves #59 
Resolves #163
Resolves #164
Resolves #165