### PR TITLE
Update CI dependecies

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:
-          version: 3.11.3
+          version: 3.12.3
 
       - name: Install unittest plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.3.1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
           go-version: '>=1.19.0'
 
       - name: Install kubeconform
-        run: go install github.com/yannh/kubeconform/cmd/kubeconform@v0.6.2
+        run: go install github.com/yannh/kubeconform/cmd/kubeconform@v0.6.3
 
       - name: kubeconform
         run: ./scripts/kubeconform.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Helm
         uses: azure/setup-helm@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: GitHub slug
-        uses: rlespinasse/github-slug-action@3.1.0
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 8
 
       - name: Make releases directory structure
         run: mkdir -p $GITHUB_WORKSPACE/${{ env.GITHUB_REF_SLUG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: GitHub slug
         uses: rlespinasse/github-slug-action@3.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:
-          version: 3.9.4
+          version: 3.12.3
 
       - name: helm lint
         run: helm lint helm-chart-sources/*


### PR DESCRIPTION
The original intention was to remove warning presented e.g. here:

https://github.com/criblio/helm-charts/actions/runs/5647881903
![Screenshot from 2023-08-20 21-52-16](https://github.com/criblio/helm-charts/assets/39981869/a561bc5c-7c3d-4dc0-9eb0-1c97b48e0c29)

Besides the above I allowed myself to bump other deps as well.