### PR TITLE
Adds support for statefulset worker deployment

### DIFF
--- a/common_docs/EXTRA_EXAMPLES.md
+++ b/common_docs/EXTRA_EXAMPLES.md
@@ -81,7 +81,11 @@ extraSecretMounts:
 ## Using extraVolumeMounts <a name="extraVolumeMounts"></a>
 _Availability: logstream-workergroup and logstream-leader_
 
-Use  `extraVolumeMounts` to mount multiple volume types within a pod. If you specify an `existingClaim` attribute, it will mount the specified Persistent Volume Claim (PVC) as a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). If you instead specify a `hostPath` attribute, it will mount that path from the host node into the Pod as a [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) volume. If you include neither, `extraVolumeMounts` will treat the definition as an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) mount.
+Use  `extraVolumeMounts` to mount multiple volume types within a pod. If you specify an `existingClaim` attribute, it will mount the specified Persistent Volume Claim (PVC) as a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). If you instead specify a `hostPath` attribute, it will mount that path from the host node into the Pod as a [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) volume. If you include none of the above, `extraVolumeMounts` will treat the definition as an [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) mount.
+
+_logstream-workergroup only_
+
+If you specify a `extraVolumeMounts.claimTemplate` attribute (and you have specified a `statefulset` deployment), it will create a [new PVC for each Pod in the set](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) based on the object provided.  
 
 <dl>
 <dt>name</dt>
@@ -98,8 +102,8 @@ Use  `extraVolumeMounts` to mount multiple volume types within a pod. If you spe
 <dd>This performs the same function as <code>subPath</code>, but allows you to define that subpath using environment variables. This is useful on shared storage (like EFS, for example), where you might want each pod to mount a subdirectory that is named after the pod. 
 <dt>readOnly</dt>
 <dd>Whether to mount the volume read-only or read/write – default is read/write. </dd>
-
-
+<dt>claimTemplate</dt>
+<dd>If this is set, it decribes the PVC that will be created for each pod. <em>Statefulset deployment only.</em></dd>
 </dl>
 
 ### Example

--- a/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
+++ b/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
@@ -116,6 +116,7 @@ tolerations:
 {{- end }}
 
 volumes: 
+  {{- if (ne .Values.deployment "statefulset") -}}
   {{- range .Values.extraVolumeMounts }}
   - name: {{ .name }}
     {{- if .existingClaim }}
@@ -127,6 +128,7 @@ volumes:
     {{- else }}
     emptyDir: {}
     {{- end }}
+  {{- end }}
   {{- end }}
   {{- range .Values.extraConfigmapMounts }}
   - name: {{ .name }}

--- a/helm-chart-sources/logstream-workergroup/templates/hpa.yaml
+++ b/helm-chart-sources/logstream-workergroup/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if (and .Values.autoscaling.enabled (or (eq .Values.deployment "deployment") (eq .Values.deployment "statefulset"))) }}
 {{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
 apiVersion: autoscaling/v2
 {{- else }}
@@ -17,7 +17,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ if (eq .Values.deployment "deployment") }}Deployment{{- else }}StatefulSet{{- end }}
     name: {{ include "logstream-workergroup.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}

--- a/helm-chart-sources/logstream-workergroup/templates/statefulset.yaml
+++ b/helm-chart-sources/logstream-workergroup/templates/statefulset.yaml
@@ -12,7 +12,7 @@ spec:
     matchLabels:
       {{- include "logstream-workergroup.selectorLabels" . | nindent 6 }}
   {{- if (.Values.strategy) }}
-  {{- if (ne .Values.strategy.type "RollingUpdate") }}
+  {{- if and (ne .Values.strategy.type "OnDelete") (ne .Values.strategy.type "RollingUpdate") }}
       {{- fail (printf "Not a valid strategy type for StatefulSet (%s)" .Values.strategy.type) }}
   {{- end }}
   updateStrategy:
@@ -30,8 +30,12 @@ spec:
       {{- include "workergroup.pod" . | nindent 8 }}
   volumeClaimTemplates:  
     {{- range .Values.extraVolumeMounts }}
-    {{- if .claimTemplate }}
-    - {{ .claimTemplate | toYaml | indent 6 | trim }}
+    {{- if .existingClaim }}
+      {{- fail (printf "Cannot use existing volume claim in extra volume mount for Statefulset (%s)" .name) }}
     {{- end }}
+    {{- if empty .claimTemplate }}
+      {{- fail (printf "Missing volume claim template in extra volume mount for Statefulset (%s) " .name) }}
+    {{- end }}
+    - {{ .claimTemplate | toYaml | indent 6 | trim }}
     {{- end }}
 {{- end }}

--- a/helm-chart-sources/logstream-workergroup/templates/statefulset.yaml
+++ b/helm-chart-sources/logstream-workergroup/templates/statefulset.yaml
@@ -1,0 +1,37 @@
+{{- if (eq .Values.deployment "statefulset") -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "logstream-workergroup.fullname" . }}
+  labels:
+    {{- include "logstream-workergroup.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "logstream-workergroup.fullname" . }}
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "logstream-workergroup.selectorLabels" . | nindent 6 }}
+  {{- if (.Values.strategy) }}
+  {{- if (ne .Values.strategy.type "RollingUpdate") }}
+      {{- fail (printf "Not a valid strategy type for StatefulSet (%s)" .Values.strategy.type) }}
+  {{- end }}
+  updateStrategy:
+    {{- toYaml .Values.strategy | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "logstream-workergroup.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- include "workergroup.pod" . | nindent 8 }}
+  volumeClaimTemplates:  
+    {{- range .Values.extraVolumeMounts }}
+    {{- if .claimTemplate }}
+    - {{ .claimTemplate | toYaml | indent 6 | trim }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm-chart-sources/logstream-workergroup/tests/fixtures/statefulset.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/fixtures/statefulset.yaml
@@ -1,0 +1,14 @@
+deployment: statefulset
+
+extraVolumeMounts:
+ - name: test-volume
+   mountPath: /var/tmp/test-volume
+   readOnly: false
+   claimTemplate:
+     metadata:
+       name: test-volume
+     spec:
+       accessModes: [ "ReadWriteOnce" ]
+       resources:
+         requests:
+           storage: 1Gi

--- a/helm-chart-sources/logstream-workergroup/tests/hpa_test.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/hpa_test.yaml
@@ -23,3 +23,24 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-logstream-workergroup-g-o-a-t
+
+  - it: Should target the correct default resource
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+
+  - it: Should target the correct StatefulSet resource
+    set:
+      deployment: statefulset
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: StatefulSet
+
+  - it: Should not be enabled for DaemonSet deployments
+    set:
+      deployment: daemonset
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm-chart-sources/logstream-workergroup/tests/statefulset_test.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/statefulset_test.yaml
@@ -1,0 +1,100 @@
+suite: Deployment
+templates:
+  - statefulset.yaml
+
+tests:
+  - it: Should not have a strategy by default
+    set:
+      deployment: statefulset
+    asserts:
+      - isNull:
+          path: spec.strategy
+      - isNull:
+          path: spec.updateStrategy
+
+  - it: Should have a custom strategy
+    set:
+      deployment: statefulset
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+          maxSurge: 1
+    asserts:
+      - isNull:
+          path: spec.strategy
+      - isNotNull:
+          path: spec.updateStrategy
+      - equal:
+          path: spec.updateStrategy
+          value:
+            type: RollingUpdate
+            rollingUpdate:
+              maxUnavailable: 1
+              maxSurge: 1
+
+  - it: Should fail on bad strategy
+    set:
+      deployment: statefulset
+      strategy:
+        type: GOAT
+    asserts:
+      - failedTemplate:
+          errorMessage: Not a valid strategy type for StatefulSet (GOAT)
+
+  - it: Should have no volume claim templates by default
+    set:
+      deployment: statefulset
+    asserts:
+      - isNull:
+          path: spec.volumeClaimTemplates
+
+  - it: Should fail on missing claim template
+    set:
+      deployment: statefulset
+      extraVolumeMounts:
+        - name: test
+    asserts:
+      - failedTemplate:
+          errorMessage: Missing volume claim template in extra volume mount for Statefulset (test)
+
+  - it: Should fail on existing claim
+    set:
+      deployment: statefulset
+      extraVolumeMounts:
+        - name: test
+          existingClaim: invalid
+    asserts:
+      - failedTemplate:
+          errorMessage: Cannot use existing volume claim in extra volume mount for Statefulset (test)
+
+  - it: Should have persistent volume claim templates
+    set:
+      deployment: statefulset
+      extraVolumeMounts:
+        - name: persistent-queue
+          claimTemplate:
+            metadata:
+              name: persistent-queue
+            spec:
+              accessModes: ["ReadWriteOnce"]
+              storageClassName: static-cribl-wg-pq
+              resources:
+                requests:
+                  storage: 20Gi
+    asserts:
+      - isNotNull:
+          path: spec.volumeClaimTemplates
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.volumeClaimTemplates
+          content: 
+            metadata:
+              name: persistent-queue
+            spec:
+              accessModes: ["ReadWriteOnce"]
+              storageClassName: static-cribl-wg-pq
+              resources:
+                requests:
+                  storage: 20Gi

--- a/helm-chart-sources/logstream-workergroup/values.yaml
+++ b/helm-chart-sources/logstream-workergroup/values.yaml
@@ -193,3 +193,10 @@ extraObjects: {}
 extraLabels: {}
 # key: value
 # key2: value2
+
+# Extra volumes to mount into each pod
+extraVolumeMounts: {}
+# - name: test-volume
+#   mountPath: /var/tmp/test-volume
+#   readOnly: false
+#   existingClaim: test-volume

--- a/helm-chart-sources/logstream-workergroup/values.yaml
+++ b/helm-chart-sources/logstream-workergroup/values.yaml
@@ -196,7 +196,21 @@ extraLabels: {}
 
 # Extra volumes to mount into each pod
 extraVolumeMounts: {}
+# For deployments and daemonsets use `existingClaim`
 # - name: test-volume
 #   mountPath: /var/tmp/test-volume
 #   readOnly: false
-#   existingClaim: test-volume
+#   existingClaim: test-volume-claim
+
+# For statefulsets use `claimTemplate`
+# - name: test-volume
+#   mountPath: /var/tmp/test-volume
+#   readOnly: false
+#   claimTemplate: 
+#     metadata:
+#       name: test-volume
+#     spec:
+#       accessModes: [ "ReadWriteOnce" ]
+#       resources:
+#         requests:
+#           storage: 1Gi


### PR DESCRIPTION
This change allows Cribl workers to be deployed using a Kubernetes [statefulset](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset) (See issue #136) .  This is useful when using source or destination persistent queuing with EFS volumes as restarted pods will be re-attached to the correct persistent volume and the queue processed correctly.

To use a statefulset deployment configure the attribute `deployment` to the new value `statefulset` and 
 the new attribute `extraVolumeMounts.claimTemplate` to an object describing the persistent volume claim during deployment of the `logstream-workergroup` Helm chart.

**Example**

```yaml
deployment: statefulset

extraVolumeMounts:
- name: persistent-queue
  mountPath: /opt/cribl/queues
  readOnly: false
  claimTemplate:
    metadata:
      name: persistent-queue
    spec:
      accessModes:
        - ReadWriteOnce
      resources:
        requests:
          storage: 20Gi
```

Important: Ensure when configuring your destination queues that the 'Queue file path' setting is set to `/opt/cribl/queues`.