### PR TITLE
Allow custom RBAC names

### DIFF
--- a/helm-chart-sources/edge/templates/common/_helpers.tpl
+++ b/helm-chart-sources/edge/templates/common/_helpers.tpl
@@ -64,3 +64,15 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+
+{{/*
+Allows for overriding the default RBAC naming scheme
+*/}}
+{{- define "common.rbacName" }}
+{{- if .Values.rbac.name }}
+{{- .Values.rbac.name | quote }}
+{{- else }}
+{{- printf "%s:%s:%s" (include "common.fullname" .) (include "common.name" .) .Release.Namespace | quote }}
+{{- end }}
+{{- end }}

--- a/helm-chart-sources/edge/templates/rbac/clusterrole.yaml
+++ b/helm-chart-sources/edge/templates/rbac/clusterrole.yaml
@@ -3,7 +3,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "common.fullname" . }}:{{ include "common.name" . }}:{{ .Release.Namespace }}
+  name: {{ include "common.rbacName" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
   {{- with .Values.rbac.annotations }}

--- a/helm-chart-sources/edge/templates/rbac/clusterrolebinding.yaml
+++ b/helm-chart-sources/edge/templates/rbac/clusterrolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "common.fullname" . }}:{{ include "common.name" . }}:{{ .Release.Namespace }}
+  name: {{ include "common.rbacName" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
 subjects:
@@ -13,5 +13,5 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "common.fullname" . }}:{{ include "common.name" . }}:{{ .Release.Namespace }}
+  name: {{ include "common.rbacName" . }}
 {{- end }}

--- a/helm-chart-sources/edge/templates/rbac/role.yaml
+++ b/helm-chart-sources/edge/templates/rbac/role.yaml
@@ -3,7 +3,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "common.fullname" . }}:{{ include "common.name" . }}:{{ .Release.Namespace }}
+  name: {{ include "common.rbacName" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
   {{- with .Values.rbac.annotations }}

--- a/helm-chart-sources/edge/templates/rbac/rolebinding.yaml
+++ b/helm-chart-sources/edge/templates/rbac/rolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "common.fullname" . }}:{{ include "common.name" . }}:{{ .Release.Namespace }}
+  name: {{ include "common.rbacName" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
 subjects:
@@ -12,5 +12,5 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "common.fullname" . }}:{{ include "common.name" . }}:{{ .Release.Namespace }}
+  name: {{ include "common.rbacName" . }}
 {{- end }}

--- a/helm-chart-sources/edge/tests/rbac_test.yaml
+++ b/helm-chart-sources/edge/tests/rbac_test.yaml
@@ -4,6 +4,7 @@ templates:
   - rbac/clusterrole.yaml
   - rbac/role.yaml
   - rbac/rolebinding.yaml
+  - rbac/clusterrolebinding.yaml
 values:
   - ./values/leader.yaml
 tests:
@@ -112,3 +113,51 @@ tests:
           any: true
           content:
             fake: true
+
+  - it: Correctly uses default rbac name
+    templates:
+      - rbac/role.yaml
+      - rbac/clusterrole.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-edge:edge:NAMESPACE
+
+  - it: Correctly uses default rbac name for bindings
+    templates:
+      - rbac/rolebinding.yaml
+      - rbac/clusterrolebinding.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-edge:edge:NAMESPACE
+      - equal:
+          path: roleRef.name
+          value: RELEASE-NAME-edge:edge:NAMESPACE
+
+  - it: Correctly uses overridden rbac name
+    templates:
+      - rbac/role.yaml
+      - rbac/clusterrole.yaml
+    set:
+      rbac:
+        name: goaty-mcgoatface
+    asserts:
+      - equal:
+          path: metadata.name
+          value: goaty-mcgoatface
+
+  - it: Correctly uses overridden rbac name for bindings
+    templates:
+      - rbac/rolebinding.yaml
+      - rbac/clusterrolebinding.yaml
+    set:
+      rbac:
+        name: goaty-mcgoatface
+    asserts:
+      - equal:
+          path: metadata.name
+          value: goaty-mcgoatface
+      - equal:
+          path: roleRef.name
+          value: goaty-mcgoatface

--- a/helm-chart-sources/edge/values.yaml
+++ b/helm-chart-sources/edge/values.yaml
@@ -82,6 +82,7 @@ serviceAccount:
 # Cluster Roles
 rbac:
   create: true
+  # name:
   annotations: {}
   # Required namespace-scoped resources
   roleRules:

--- a/helm-chart-sources/logstream-workergroup/templates/_helpers.tpl
+++ b/helm-chart-sources/logstream-workergroup/templates/_helpers.tpl
@@ -64,3 +64,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Allows for overriding the default RBAC naming scheme
+*/}}
+{{- define "logstream-workergroup.rbacName" }}
+{{- if .Values.rbac.name }}
+{{- .Values.rbac.name | quote }}
+{{- else }}
+{{- printf "%s:%s:%s" (include "logstream-workergroup.fullname" .) "logstream-workergroup" .Release.Namespace | quote }}
+{{- end }}
+{{- end }}

--- a/helm-chart-sources/logstream-workergroup/templates/role.yaml
+++ b/helm-chart-sources/logstream-workergroup/templates/role.yaml
@@ -3,7 +3,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "logstream-workergroup.fullname" . }}:logstream-workergroup:{{ .Release.Namespace }}
+  name: {{ include "logstream-workergroup.rbacName" . }}
   labels:
     {{- include "logstream-workergroup.labels" . | nindent 4 }}
 rules:

--- a/helm-chart-sources/logstream-workergroup/templates/rolebinding.yaml
+++ b/helm-chart-sources/logstream-workergroup/templates/rolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "logstream-workergroup.fullname" . }}:logstream-workergroup:{{ .Release.Namespace }}
+  name: {{ include "logstream-workergroup.rbacName" . }}
   labels:
     {{- include "logstream-workergroup.labels" . | nindent 4 }}
 subjects:
@@ -13,5 +13,5 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "logstream-workergroup.fullname" . }}:logstream-workergroup:{{ .Release.Namespace }}
+  name: {{ include "logstream-workergroup.rbacName" . }}
 {{- end }}

--- a/helm-chart-sources/logstream-workergroup/tests/fixtures/rbac.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/fixtures/rbac.yaml
@@ -1,0 +1,5 @@
+serviceAccount:
+  create: true
+rbac:
+  create: true
+  name: foo-bar_baz

--- a/helm-chart-sources/logstream-workergroup/tests/rbac_test.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/rbac_test.yaml
@@ -1,0 +1,48 @@
+suite: RBAC
+templates:
+  - role.yaml
+  - rolebinding.yaml
+tests:
+  - it: Correctly uses default rbac name
+    templates:
+      - role.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-logstream-workergroup:logstream-workergroup:NAMESPACE
+
+  - it: Correctly uses default rbac name for bindings
+    templates:
+      - rolebinding.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-logstream-workergroup:logstream-workergroup:NAMESPACE
+      - equal:
+          path: roleRef.name
+          value: RELEASE-NAME-logstream-workergroup:logstream-workergroup:NAMESPACE
+
+  - it: Correctly uses overridden rbac name
+    templates:
+      - role.yaml
+    set:
+      rbac:
+        name: goaty-mcgoatface
+    asserts:
+      - equal:
+          path: metadata.name
+          value: goaty-mcgoatface
+
+  - it: Correctly uses overridden rbac name for bindings
+    templates:
+      - rolebinding.yaml
+    set:
+      rbac:
+        name: goaty-mcgoatface
+    asserts:
+      - equal:
+          path: metadata.name
+          value: goaty-mcgoatface
+      - equal:
+          path: roleRef.name
+          value: goaty-mcgoatface

--- a/helm-chart-sources/logstream-workergroup/values.yaml
+++ b/helm-chart-sources/logstream-workergroup/values.yaml
@@ -6,6 +6,7 @@ replicaCount: 1
 
 rbac:
   create: true
+  # name:
   apiGroups: 
   - core
   resources:

--- a/scripts/kubeconform.sh
+++ b/scripts/kubeconform.sh
@@ -11,6 +11,8 @@ for chart in $DIR/helm-chart-sources/*; do
 
   for values in $chart/tests/fixtures/*; do
     TEST=$(basename $values)
+    echo "** Linting chart"
+    helm lint -f $values $chart
     echo "** Evaluating fixture $TEST"
     helm template -f $values $chart | kubeconform -summary
   done


### PR DESCRIPTION
Defining the following in the chart allows for a custom name on RBAC resources:

```
rbac:
  name: goat
```

Leaving blank or undefined uses the current format. This macro has been moved into the `_helpers.tpl` file.