### PR TITLE
Worker Group Ingress fixes and update Helm unittest plugin to 0.3.5

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
           version: 3.11.3
 
       - name: Install unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.3.1
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.3.5
 
       - name: helm lint
         run: helm lint helm-chart-sources/*

--- a/helm-chart-sources/appscope/tests/configmap_test.yaml
+++ b/helm-chart-sources/appscope/tests/configmap_test.yaml
@@ -13,7 +13,7 @@ tests:
 
   - it: Contains the events and metrics destination
     asserts:
-      - isNotNull:
+      - exists:
           path: data["scope.yml"]
       - matchRegex:
           path: data["scope.yml"]

--- a/helm-chart-sources/appscope/tests/deployment_test.yaml
+++ b/helm-chart-sources/appscope/tests/deployment_test.yaml
@@ -13,7 +13,7 @@ tests:
           
   - it: Contains the events and metrics destination
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.template.spec.containers[0].args[1]
       - equal:
           path: spec.template.spec.containers[0].args[1]

--- a/helm-chart-sources/edge/tests/daemonset_test.yaml
+++ b/helm-chart-sources/edge/tests/daemonset_test.yaml
@@ -51,7 +51,7 @@ tests:
 
   - it: Doesn't set a default priorityClassName
     asserts:
-      - isNull:
+      - notExists:
           path: spec.template.spec.priorityClassName
 
   - it: Should set extraEnvFrom
@@ -63,7 +63,7 @@ tests:
             fieldRef:
               fieldPath: metadata.name
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.template.spec.containers[0].env
       - contains:
           path: spec.template.spec.containers[0].env
@@ -82,7 +82,7 @@ tests:
         - name: ENV2
           value: test
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.template.spec.containers[0].env
       - contains:
           path: spec.template.spec.containers[0].env
@@ -108,7 +108,7 @@ tests:
             fieldRef:
               fieldPath: metadata.name
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.template.spec.containers[0].env
       - contains:
           path: spec.template.spec.containers[0].env
@@ -131,7 +131,7 @@ tests:
       extraEnv:
         EEEEE: "ABC"
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.template.spec.containers[0].env
       - contains:
           path: spec.template.spec.containers[0].env
@@ -143,7 +143,7 @@ tests:
     set:
       priorityClassName: gotta-goat-fast
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.template.spec.priorityClassName
       - equal:
           path: spec.template.spec.priorityClassName
@@ -155,7 +155,7 @@ tests:
         goat: true
         kubernetes.io/os: linux
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.template.spec.nodeSelector
       - equal:
           path: spec.template.spec.nodeSelector
@@ -170,7 +170,7 @@ tests:
           operator: "Exists"
           effect: "NoSchedule"
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.template.spec.tolerations
       - equal:
           path: spec.template.spec.tolerations

--- a/helm-chart-sources/edge/tests/extras_test.yaml
+++ b/helm-chart-sources/edge/tests/extras_test.yaml
@@ -42,6 +42,7 @@ tests:
       - containsDocument:
           apiVersion: v1
           kind: Pod
+          any: true
       - equal:
           path: metadata.name
           value: foo

--- a/helm-chart-sources/edge/tests/labels_test.yaml
+++ b/helm-chart-sources/edge/tests/labels_test.yaml
@@ -9,9 +9,9 @@ tests:
         key: value
         key2: value2
     asserts:
-      - isNotNull:
+      - exists:
           path: metadata.labels.key
-      - isNotNull:
+      - exists:
           path: metadata.labels.key2
       - equal:
           path: metadata.labels.key

--- a/helm-chart-sources/edge/tests/secret_test.yaml
+++ b/helm-chart-sources/edge/tests/secret_test.yaml
@@ -11,7 +11,7 @@ tests:
       - equal:
           path: stringData.CRIBL_DIST_LEADER_URL
           value: tcp://fake@example:4200?group=foo
-      - isNull:
+      - notExists:
           path: stringData.CRIBL_BOOTSTRAP
 
   - it: Sets CRIBL_BOOTSTRAP from cribl.config

--- a/helm-chart-sources/edge/tests/service_test.yaml
+++ b/helm-chart-sources/edge/tests/service_test.yaml
@@ -25,7 +25,7 @@ tests:
               targetPort: 9420
               protocol: TCP
               name: edge-api
-      - isNull:
+      - notExists:
           path: spec.loadBalancerIP
 
   - it: Uses custom ports
@@ -66,7 +66,7 @@ tests:
         type: ClusterIP # redundant
         loadBalancerIP: 1.2.3.4
     asserts:
-      - isNull:
+      - notExists:
           path: spec.loadBalancerIP
 
   - it: Should use the externalTrafficPolicy when set to type LoadBalancer

--- a/helm-chart-sources/logstream-leader/tests/deployment_test.yaml
+++ b/helm-chart-sources/logstream-leader/tests/deployment_test.yaml
@@ -4,18 +4,18 @@ templates:
 tests:
   - it: Should have health checks by default
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.template.spec.containers[0].readinessProbe
-      - isNotNull:
+      - exists:
           path: spec.template.spec.containers[0].livenessProbe
 
   - it: Should disable health checks
     set:
       config.probes: false
     asserts:
-      - isNull:
+      - notExists:
           path: spec.template.spec.containers[0].readinessProbe
-      - isNull:
+      - notExists:
           path: spec.template.spec.containers[0].livenessProbe
 
   - it: Should customize health checks

--- a/helm-chart-sources/logstream-leader/tests/extras_test.yaml
+++ b/helm-chart-sources/logstream-leader/tests/extras_test.yaml
@@ -40,6 +40,7 @@ tests:
       - containsDocument:
           apiVersion: v1
           kind: Pod
+          any: true
       - equal:
           path: metadata.name
           value: foo

--- a/helm-chart-sources/logstream-leader/tests/labels_test.yaml
+++ b/helm-chart-sources/logstream-leader/tests/labels_test.yaml
@@ -7,9 +7,9 @@ tests:
         key: value
         key2: value2
     asserts:
-      - isNotNull:
+      - exists:
           path: metadata.labels.key
-      - isNotNull:
+      - exists:
           path: metadata.labels.key2
       - equal:
           path: metadata.labels.key

--- a/helm-chart-sources/logstream-leader/tests/securitycontext_test.yaml
+++ b/helm-chart-sources/logstream-leader/tests/securitycontext_test.yaml
@@ -4,7 +4,7 @@ templates:
 tests:
   - it: Should not set securitycontext by default
     asserts:
-      - isNull:
+      - notExists:
           path: spec.template.spec.securityContext
 
   - it: Should set correct command
@@ -36,12 +36,12 @@ tests:
       securityContext:
         runAsUser: 1000
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.template.spec.containers[0].volumeMounts[1]
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[1].name
           value: gitconfig
-      - isNotNull:
+      - exists:
           path: spec.template.spec.volumes[1]
       - equal:
           path: spec.template.spec.volumes[1].name

--- a/helm-chart-sources/logstream-workergroup/templates/ingress.yaml
+++ b/helm-chart-sources/logstream-workergroup/templates/ingress.yaml
@@ -6,7 +6,7 @@ kind: Ingress
 metadata:
   name: {{ include "logstream-workergroup.fullname" $ }}-{{ .name }}
   annotations:
-    {{- $annotations := merge .annotations $.Values.ingress.annotations }}
+    {{- $annotations := merge (.annotations | default dict) $.Values.ingress.annotations }}
     {{- toYaml $annotations | nindent 4 }}
 spec:
   {{- with .tls }}

--- a/helm-chart-sources/logstream-workergroup/templates/service.yaml
+++ b/helm-chart-sources/logstream-workergroup/templates/service.yaml
@@ -15,7 +15,9 @@ spec:
         targetPort: {{ .port }}
         protocol: {{ .protocol }}
         name: {{ .name }}
+        {{- if .nodePort }}
         nodePort: {{ .nodePort }}
+        {{- end }}
       {{- end }}
   selector:
     {{- include "logstream-workergroup.selectorLabels" . | nindent 4 }}

--- a/helm-chart-sources/logstream-workergroup/templates/statefulset.yaml
+++ b/helm-chart-sources/logstream-workergroup/templates/statefulset.yaml
@@ -34,7 +34,7 @@ spec:
       {{- fail (printf "Cannot use existing volume claim in extra volume mount for Statefulset (%s)" .name) }}
     {{- end }}
     {{- if empty .claimTemplate }}
-      {{- fail (printf "Missing volume claim template in extra volume mount for Statefulset (%s) " .name) }}
+      {{- fail (printf "Missing volume claim template in extra volume mount for Statefulset (%s)" .name) }}
     {{- end }}
     - {{ .claimTemplate | toYaml | indent 6 | trim }}
     {{- end }}

--- a/helm-chart-sources/logstream-workergroup/tests/daemonset_test.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/daemonset_test.yaml
@@ -6,9 +6,9 @@ tests:
     set:
       deployment: daemonset
     asserts:
-      - isNull:
+      - notExists:
           path: spec.strategy
-      - isNull:
+      - notExists:
           path: spec.updateStrategy
 
   - it: Should have a custom strategy
@@ -20,9 +20,9 @@ tests:
           maxUnavailable: 1
           maxSurge: 1
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.updateStrategy
-      - isNull:
+      - notExists:
           path: spec.strategy
       - equal:
           path: spec.updateStrategy

--- a/helm-chart-sources/logstream-workergroup/tests/deployment_test.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/deployment_test.yaml
@@ -4,27 +4,27 @@ templates:
 tests:
   - it: Should have health checks by default
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.template.spec.containers[0].readinessProbe
-      - isNotNull:
+      - exists:
           path: spec.template.spec.containers[0].livenessProbe
 
   - it: Should disable health checks
     set:
       config.probes: false
     asserts:
-      - isNull:
+      - notExists:
           path: spec.template.spec.containers[0].readinessProbe
-      - isNull:
+      - notExists:
           path: spec.template.spec.containers[0].livenessProbe
 
   - it: Should disable one health check
     set:
       config.readinessProbe: null
     asserts:
-      - isNull:
+      - notExists:
           path: spec.template.spec.containers[0].readinessProbe
-      - isNotNull:
+      - exists:
           path: spec.template.spec.containers[0].livenessProbe
 
   - it: Should customize health checks
@@ -59,9 +59,9 @@ tests:
 
   - it: Should not have a strategy by default
     asserts:
-      - isNull:
+      - notExists:
           path: spec.strategy
-      - isNull:
+      - notExists:
           path: spec.updateStrategy
 
   - it: Should have a custom strategy
@@ -72,9 +72,9 @@ tests:
           maxUnavailable: 1
           maxSurge: 1
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.strategy
-      - isNull:
+      - notExists:
           path: spec.updateStrategy
       - equal:
           path: spec.strategy
@@ -100,9 +100,9 @@ tests:
         topologySpreadConstraints:
           - goat: true
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.template.spec.foo
-      - isNotNull:
+      - exists:
           path: spec.template.spec.topologySpreadConstraints
       - equal:
           path: spec.template.spec.foo
@@ -121,7 +121,7 @@ tests:
           value: "value1"
           effect: "NoSchedule"
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.template.spec.tolerations
       - equal:
           path: spec.template.spec.tolerations

--- a/helm-chart-sources/logstream-workergroup/tests/extras_test.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/extras_test.yaml
@@ -40,6 +40,7 @@ tests:
       - containsDocument:
           apiVersion: v1
           kind: Pod
+          any: true
       - equal:
           path: metadata.name
           value: foo

--- a/helm-chart-sources/logstream-workergroup/tests/fixtures/ingress.yml
+++ b/helm-chart-sources/logstream-workergroup/tests/fixtures/ingress.yml
@@ -1,0 +1,10 @@
+ingress:
+  enable: true
+  annotations:
+    foo: bar
+  ingress:
+    - name: goat
+      rules:
+        - paths:
+          - path: /
+            port: 8000

--- a/helm-chart-sources/logstream-workergroup/tests/fixtures/wli.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/fixtures/wli.yaml
@@ -1,0 +1,15 @@
+env:
+  AWS_ROLE_ARN: goat
+  AWS_WEB_IDENTITY_TOKEN_FILE: /var/run/secrets/aws-iam-token/serviceaccount/token
+  AWS_REGION: us-west-2
+extraSecretMounts:
+  - name: aws-iam-token
+    mountPath: /var/run/secrets/aws-iam-token/serviceaccount
+    readOnly: true
+    projected:
+      defaultMode: 420
+      sources:
+        - serviceAccountToken:
+            audience: sts.amazonaws.com
+            expirationSeconds: 86400
+            path: token

--- a/helm-chart-sources/logstream-workergroup/tests/ingress_test.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/ingress_test.yaml
@@ -24,7 +24,7 @@ tests:
       - containsDocument:
           kind: Ingress
           apiVersion: networking.k8s.io/v1
-      - isNotNullOrEmpty:
+      - exists:
           path: spec.rules[0]
       - equal:
           path: spec.rules[0].http.paths[0].path
@@ -49,7 +49,7 @@ tests:
 
     asserts:
       - notFailedTemplate: {}
-      - isNotNullOrEmpty:
+      - exists:
           path: metadata.annotations
       - equal:
           path: metadata.annotations
@@ -73,7 +73,7 @@ tests:
 
     asserts:
       - notFailedTemplate: {}
-      - isNotNullOrEmpty:
+      - exists:
           path: metadata.annotations
       - equal:
           path: metadata.annotations
@@ -100,7 +100,7 @@ tests:
 
     asserts:
       - notFailedTemplate: { }
-      - isNotNullOrEmpty:
+      - exists:
           path: metadata.annotations
       - equal:
           path: metadata.annotations

--- a/helm-chart-sources/logstream-workergroup/tests/ingress_test.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/ingress_test.yaml
@@ -1,0 +1,110 @@
+suite: Ingress
+templates:
+  - ingress.yaml
+tests:
+  - it: Should not create an ingress resource by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create an ingress resource when enabled
+    set:
+      ingress:
+        enable: true
+        ingress:
+          - name: goat
+            rules:
+              - paths:
+                - path: /
+                  port: 8001
+
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          kind: Ingress
+          apiVersion: networking.k8s.io/v1
+      - isNotNullOrEmpty:
+          path: spec.rules[0]
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 8001
+
+  - it: Should use "global" annotations
+    set:
+      ingress:
+        enable: true
+        annotations:
+          foo: bar
+          goat: true
+        ingress:
+          - name: goat
+            rules:
+              - paths:
+                  - path: /
+                    port: 8001
+
+    asserts:
+      - notFailedTemplate: {}
+      - isNotNullOrEmpty:
+          path: metadata.annotations
+      - equal:
+          path: metadata.annotations
+          value:
+            foo: bar
+            goat: true
+
+  - it: Should use "local" annotations
+    set:
+      ingress:
+        enable: true
+        ingress:
+          - name: goat
+            annotations:
+              foo: bar
+              goat: true
+            rules:
+              - paths:
+                  - path: /
+                    port: 8001
+
+    asserts:
+      - notFailedTemplate: {}
+      - isNotNullOrEmpty:
+          path: metadata.annotations
+      - equal:
+          path: metadata.annotations
+          value:
+            foo: bar
+            goat: true
+
+  - it: Should merge annotations
+    set:
+      ingress:
+        enable: true
+        annotations:
+          top: gun
+          override: me
+        ingress:
+          - name: goat
+            annotations:
+              need: speed
+              override: yes
+            rules:
+              - paths:
+                  - path: /
+                    port: 8001
+
+    asserts:
+      - notFailedTemplate: { }
+      - isNotNullOrEmpty:
+          path: metadata.annotations
+      - equal:
+          path: metadata.annotations
+          value:
+            top: gun
+            need: speed
+            override: yes

--- a/helm-chart-sources/logstream-workergroup/tests/labels_test.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/labels_test.yaml
@@ -7,9 +7,9 @@ tests:
         key: value
         key2: value2
     asserts:
-      - isNotNull:
+      - exists:
           path: metadata.labels.key
-      - isNotNull:
+      - exists:
           path: metadata.labels.key2
       - equal:
           path: metadata.labels.key
@@ -26,9 +26,9 @@ tests:
         key: value
         key2: value2
     asserts:
-      - isNotNull:
+      - exists:
           path: metadata.labels.key
-      - isNotNull:
+      - exists:
           path: metadata.labels.key2
       - equal:
           path: metadata.labels.key

--- a/helm-chart-sources/logstream-workergroup/tests/service_test.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/service_test.yaml
@@ -4,7 +4,7 @@ templates:
 tests:
   - it: Should not configure the externalTrafficPolicy with default values
     asserts:
-      - isNull:
+      - notExists:
           path: spec.externalTrafficPolicy
 
   - it: Should not configure the externalTrafficPolicy when type is Cluster IP
@@ -13,7 +13,7 @@ tests:
         type: ClusterIP
         externalTrafficPolicy: Local
     asserts:
-      - isNull:
+      - notExists:
           path: spec.externalTrafficPolicy
 
   - it: Should configure the externalTrafficPolicy when type is LoadBalancer
@@ -38,7 +38,7 @@ tests:
 
   - it: Should not configure the loadBalancerSourceRanges by default
     asserts:
-      - isNull:
+      - notExists:
           path: spec.loadBalancerSourceRanges
 
   - it: Should configure the loadBalancerSourceRanges
@@ -48,7 +48,7 @@ tests:
         - "192.168.1.0/24"
         - "172.16.0.0/16"
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.loadBalancerSourceRanges
       - equal:
           path: spec.loadBalancerSourceRanges
@@ -59,7 +59,7 @@ tests:
 
   - it: No default set for nodePort
     asserts:
-      - isNull:
+      - notExists:
           path: spec.ports[0].nodePort
 
   - it: Default values set for nodePort

--- a/helm-chart-sources/logstream-workergroup/tests/statefulset_test.yaml
+++ b/helm-chart-sources/logstream-workergroup/tests/statefulset_test.yaml
@@ -46,7 +46,7 @@ tests:
     set:
       deployment: statefulset
     asserts:
-      - isNull:
+      - isNullOrEmpty:
           path: spec.volumeClaimTemplates
 
   - it: Should fail on missing claim template
@@ -83,7 +83,7 @@ tests:
                 requests:
                   storage: 20Gi
     asserts:
-      - isNotNull:
+      - exists:
           path: spec.volumeClaimTemplates
       - hasDocuments:
           count: 1

--- a/helm-chart-sources/logstream-workergroup/values.yaml
+++ b/helm-chart-sources/logstream-workergroup/values.yaml
@@ -157,7 +157,7 @@ ingress:
   ingressClassName:
   # Array of ingresses (each entry will become an Ingress resource)
   # You must define your ingress resources!
-  ingress: {}
+  ingress: []
 #    - name: ingress-example
 #      # TLS secrets for this ingress
 #      tls: {}


### PR DESCRIPTION
Addresses two issues:

1. Incorrect default value in `values.yaml` for `ingress.ingress` value. It should be an array, not a dict. This is causing the following warning to be emitted:
```
coalesce.go:220: warning: cannot overwrite table with non table for logstream-workergroup.ingress.ingress (map[])
```

2. Adds a default dict to the ingress template for the local annotations in the merge function. If annotations are not defined in inner ingress rules, an error is thrown and the chart isn't rendered.
```
Error: INSTALLATION FAILED: template: logstream-workergroup/templates/ingress.yaml:9:30: executing "logstream-workergroup/templates/ingress.yaml" at <.annotations>: wrong type for value; expected map[string]interface {}; got interface {}
```