### PR TITLE
Patch for Issue #182

### DIFF
--- a/helm-chart-sources/logstream-leader/templates/_helpers.tpl
+++ b/helm-chart-sources/logstream-leader/templates/_helpers.tpl
@@ -64,3 +64,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+  Join annotations passed in from values.yaml for Services
+*/}}
+{{- define "logstream-leader.service.annotations" -}}
+{{- if eq .templateType "internal" }}
+{{- $intAnnotations := (merge .Values.service.annotations .Values.service.internalAnnotations) -}}
+{{ toYaml $intAnnotations }}
+{{- end }}
+{{- if eq .templateType "external" }}
+{{- $extAnnotations := (merge .Values.service.annotations .Values.service.externalAnnotations) -}}
+{{ toYaml $extAnnotations }}
+{{- end }}
+{{- end }}

--- a/helm-chart-sources/logstream-leader/templates/service-internal.yaml
+++ b/helm-chart-sources/logstream-leader/templates/service-internal.yaml
@@ -6,8 +6,7 @@ metadata:
   labels:
     {{- include "logstream-leader.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.service.internalAnnotations  | nindent 4 }}
-
+    {{- include "logstream-leader.service.annotations" (merge (dict "templateType" "internal") .) | nindent 4 }}
 spec:
   type: {{ .Values.service.internalType }}
   ports:

--- a/helm-chart-sources/logstream-leader/templates/service-internal.yaml
+++ b/helm-chart-sources/logstream-leader/templates/service-internal.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "logstream-leader.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.service.annotations  | nindent 4 }}
+    {{- toYaml .Values.service.internalAnnotations  | nindent 4 }}
 
 spec:
   type: {{ .Values.service.internalType }}

--- a/helm-chart-sources/logstream-leader/templates/service.yaml
+++ b/helm-chart-sources/logstream-leader/templates/service.yaml
@@ -6,8 +6,7 @@ metadata:
   labels:
     {{- include "logstream-leader.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.service.externalAnnotations  | nindent 4 }}
-
+    {{- include "logstream-leader.service.annotations" (merge (dict "templateType" "external") .) | nindent 4 }}
 spec:
   type: {{- if (eq $.Values.ingress.enable true) }} NodePort {{- else }} {{ .Values.service.externalType }} {{- end }}
   ports:

--- a/helm-chart-sources/logstream-leader/templates/service.yaml
+++ b/helm-chart-sources/logstream-leader/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "logstream-leader.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.service.annotations  | nindent 4 }}
+    {{- toYaml .Values.service.externalAnnotations  | nindent 4 }}
 
 spec:
   type: {{- if (eq $.Values.ingress.enable true) }} NodePort {{- else }} {{ .Values.service.externalType }} {{- end }}

--- a/helm-chart-sources/logstream-leader/tests/service_test.yaml
+++ b/helm-chart-sources/logstream-leader/tests/service_test.yaml
@@ -1,0 +1,94 @@
+suite: Service
+templates:
+  - service.yaml
+  - service-internal.yaml
+tests:
+  - it: Should not set annotations by default to the external service
+    template: service.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value: {}
+
+  - it: Should not set annotations to the internal service
+    template: service-internal.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value: {}
+
+  - it: Applies an annotation to the internal service that would be shared with the external service
+    template: service-internal.yaml
+    set:
+      service:
+        annotations:
+          foo: bar
+    asserts:
+      - equal:
+          path: metadata.annotations.foo
+          value: "bar"
+
+  - it: Applies an annotation to the external service that would be shared with the internal service
+    template: service.yaml
+    set:
+      service:
+        annotations:
+          foo: bar
+    asserts:
+      - equal:
+          path: metadata.annotations.foo
+          value: "bar"
+
+  - it: Applies an annotation to the internal service only
+    template: service-internal.yaml
+    set:
+      service:
+        internalAnnotations:
+          fizz: buzz
+    asserts:
+      - equal:
+          path: metadata.annotations.fizz
+          value: "buzz"
+
+  - it: Applies an annotation to the external service only
+    template: service.yaml
+    set:
+      service:
+        externalAnnotations:
+          fizz: buzz
+    asserts:
+      - equal:
+          path: metadata.annotations.fizz
+          value: "buzz"
+
+  - it: Applies an annotation to the external service only and also a shared annotation
+    template: service.yaml
+    set:
+      service:
+        annotations:
+          foo: 'bar'
+        externalAnnotations:
+          fizz: 'buzz'
+    asserts:
+      - equal:
+          path: metadata.annotations.foo
+          value: "bar"
+      - equal:
+          path: metadata.annotations.fizz
+          value: "buzz"
+
+  - it: Applies an annotation to the external service only and also a shared annotation
+    template: service-internal.yaml
+    set:
+      service:
+        annotations:
+          bar: 'foo'
+        internalAnnotations:
+          buzz: 'fizz'
+    asserts:
+      - equal:
+          path: metadata.annotations.bar
+          value: "foo"
+      - equal:
+          path: metadata.annotations.buzz
+          value: "fizz"

--- a/helm-chart-sources/logstream-leader/values.yaml
+++ b/helm-chart-sources/logstream-leader/values.yaml
@@ -51,7 +51,8 @@ env: {}
 service:
   internalType: ClusterIP
   externalType: LoadBalancer
-  annotations: {}
+  internalAnnotations: {}
+  externalAnnotations: {}
   ports:
     - name: api
       port: 9000

--- a/helm-chart-sources/logstream-leader/values.yaml
+++ b/helm-chart-sources/logstream-leader/values.yaml
@@ -51,7 +51,11 @@ env: {}
 service:
   internalType: ClusterIP
   externalType: LoadBalancer
+  # annotations are shared between both the internal and external Service
+  annotations: {}
+  # internalAnnotations are only applied to the internal Service
   internalAnnotations: {}
+  # externalAnnotations are only applied to the external Service
   externalAnnotations: {}
   ports:
     - name: api


### PR DESCRIPTION
This PR addresses Issue #182 and separates out the internal/external Service annotations for the logstream-leader to allow configuration of different LoadBalancer types based on annotations which is common in the cloud and on-premise with services such as MetalLB.