### PR TITLE
Add support for OpenShift, initially with Routes

### DIFF
--- a/helm-chart-sources/logstream-leader/templates/openshift-route.yaml
+++ b/helm-chart-sources/logstream-leader/templates/openshift-route.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.openshift.enable }}
+{{- if .Values.openshift.route.enable -}}
+{{- $serviceName := include "logstream-leader.fullname" . -}}
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: {{ template "logstream-leader.fullname" . }}
+  labels:
+    {{- include "logstream-leader.labels" . | nindent 4 }}
+    {{- with .Values.openshift.route.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{ toYaml .Values.openshift.route.annotations | }}
+spec:
+  host: {{ .Values.openshift.route.host }}
+  to:
+    kind: Service
+    name: {{ $serviceName }}
+    weight: 100
+  port:
+    targetPort: api
+  tls:
+    {{- toYaml .Values.openshift.route.tls | nindent  4 }}
+  wildcardPolicy: {{ .Values.openshift.route.wildcardPolicy }}
+{{- end }}
+{{- end }}

--- a/helm-chart-sources/logstream-leader/tests/openshift-route_test.yaml
+++ b/helm-chart-sources/logstream-leader/tests/openshift-route_test.yaml
@@ -1,0 +1,100 @@
+suite: OpenShift Route
+templates:
+  - openshift-route.yaml
+tests:
+  - it: Does not create an OpenShift Route by default
+    template: openshift-route.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  
+  - it: Creates an OpenShift Route resource
+    set:
+      openshift.enable: true
+    template: openshift-route.yaml
+    asserts:
+      - containsDocument:
+          kind: Route
+          apiVersion: route.openshift.io/v1
+
+  - it: Does not creates an OpenShift Route resource if OpenShift is enabled but the route is disabled, eg for use with other Ingresses
+    set:
+      openshift.enable: true
+      openshift.route.enable: false
+    template: openshift-route.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Creates an OpenShift Route with additional labels
+    set:
+      openshift.enable: true
+      openshift.route.labels:
+        foo: bar
+    template: openshift-route.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.foo
+          value: bar
+
+  - it: Creates an OpenShift Route with additional annotations
+    set:
+      openshift.enable: true
+      openshift.route.annotations:
+        fizz: buzz
+    template: openshift-route.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations.fizz
+          value: buzz
+
+  - it: Set a host for the Route
+    set:
+      openshift.enable: true
+      openshift.route.host: cribl.example.com
+    template: openshift-route.yaml
+    asserts:
+      - equal:
+          path: spec.host
+          value: cribl.example.com
+
+  - it: Check the default TLS Termination type of Edge and insecureEdgeTerminationPolicy of Redirect
+    set:
+      openshift.enable: true
+    template: openshift-route.yaml
+    asserts:
+      - equal:
+          path: spec.tls.termination
+          value: edge
+      - equal:
+          path: spec.tls.insecureEdgeTerminationPolicy
+          value: Redirect
+
+  - it: Set the TLS Termination type to passthrough
+    set:
+      openshift.enable: true
+      openshift.route.tls.termination: passthrough
+    template: openshift-route.yaml
+    asserts:
+      - equal:
+          path: spec.tls.termination
+          value: passthrough
+
+  - it: Check the default WildcardPolicy of None
+    set:
+      openshift.enable: true
+    template: openshift-route.yaml
+    asserts:
+      - equal:
+          path: spec.wildcardPolicy
+          value: None
+
+  - it: Set the WildcardPolicy to Subdomain
+    set:
+      openshift.enable: true
+      openshift.route.wildcardPolicy: Subdomain
+    template: openshift-route.yaml
+    asserts:
+      - equal:
+          path: spec.wildcardPolicy
+          value: Subdomain

--- a/helm-chart-sources/logstream-leader/values.yaml
+++ b/helm-chart-sources/logstream-leader/values.yaml
@@ -112,3 +112,16 @@ extraObjects: {}
 extraLabels: {}
 # key: value
 # key2: value2
+
+# Red Hat OpenShift specific configuration
+openshift:
+  enable: false # by default, we assume this is not an OpenShift deployment 
+  route:
+    enable: true # If this is an OpenShift deployment, create a Route for the Cribl LS Leader Service
+    annotations: {}
+    labels: {}
+    host: '' # When the host is not specified, a wildcard entry will be generated such as <service-name>-<namespace>.apps.<cluster-name>.<cluster-domain>
+    tls:
+      termination: edge # edge, passthrough, reencrypt
+      insecureEdgeTerminationPolicy: Redirect # None, Allow, Redirect
+    wildcardPolicy: None # None, Subdomain


### PR DESCRIPTION
> Addresses Issue #184 

The following PR introduces a new base value structure at `.Values.openshift`.  This enables targeting conditional manifest mutation that would support easy boolean-based deployments of the Cribl charts to Red Hat OpenShift clusters.

The first capability this structure provides is to allow the usage of OpenShift Routes automatically, and optionally in case a user wants to use a different IngressController.

Helm Unit Tests have also been included for all of the input values.

The addition of the `.Values.openshift` also provides capabilities for users to easily deploy to OpenShift for other concerns, eg Namespace/Project annotations, SecurityContextConstraint bindings, etc