### PR TITLE
Add leases to edge rbac

### DIFF
--- a/helm-chart-sources/edge/values.yaml
+++ b/helm-chart-sources/edge/values.yaml
@@ -176,7 +176,7 @@ rbac:
         - "coordination.k8s.io"
       resources:
         - leases
-      verbs: ['get', 'list', 'watch']
+      verbs: ['get']
     - apiGroups:
         - "certificates.k8s.io"
       resources:

--- a/helm-chart-sources/edge/values.yaml
+++ b/helm-chart-sources/edge/values.yaml
@@ -173,6 +173,11 @@ rbac:
         - validatingwebhookconfigurations
       verbs: ['list', 'watch']
     - apiGroups:
+        - "coordination.k8s.io"
+      resources:
+        - leases
+      verbs: ['get', 'list', 'watch']
+    - apiGroups:
         - "certificates.k8s.io"
       resources:
         - certificatesigningrequests


### PR DESCRIPTION
Allow edge resources in the cluster to access the node leases endpoint from within the cluster.

Note: my linter removed the newline at file end