### PR TITLE
Update claims.yaml

### DIFF
--- a/common_docs/EXTRA_EXAMPLES.md
+++ b/common_docs/EXTRA_EXAMPLES.md
@@ -1,3 +1,24 @@
+# Extra Examples
+This document contains examples of how to configure various scenarios in the Helm Charts.
+
+## Persistence
+_Availability: logstream-leader_
+
+The `persistence` settings for the Cribl Leader Helm Chart allow you to customize the PVC settings, or disable persistence all together by settings `enabled: false` which results in the Pod using an `emptyDir` for storage.
+
+### Example
+
+This example unsets the `claimName` so that the Helm Release name will be used for the PVC name, uses `goat-speed` for the storage class, increases the PVC requested size to 30 Gi, and adds an annotation for the AWS EBS controller to use `gp3` EBS storage. 
+
+```
+persistence:
+  claimName: 
+  storageClassName: goat-speed
+  size: 30Gi
+  annotations:
+    ebs.csi.aws.com/volumeType: gp3
+```
+
 ## Using envValueFrom<a name="envValueFrom"></a>
 _Availability: logstream-workergroup and logstream-leader_
 

--- a/helm-chart-sources/logstream-leader/README.md
+++ b/helm-chart-sources/logstream-leader/README.md
@@ -63,6 +63,7 @@ This section covers the most likely values to override. To see the full scope of
 |consolidate_volumes|boolean|If this value exists, and the `helm` command is `upgrade`, this will use the split volumes that we created in charts before 2.4 and consolidate them down to one config volume. This is a ONE-TIME event.|
 |nodeSelector|{}|Add nodeSelector values to define which nodes the pods are scheduled on - see [k8s Documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) for details and allowed values. |
 |__Extra Configuration Options__|
+|[persistence](../../common_docs/EXTRA_EXAMPLES.md#persistence)| See `values.yaml`|Persistence configuration for Leader configuration files.|          
 |[extraVolumeMounts](../../common_docs/EXTRA_EXAMPLES.md#extraVolumeMounts)|{}|Additional volumes to mount in the container.|
 |[extraSecretMounts](../../common_docs/EXTRA_EXAMPLES.md#extraSecretMounts)|[]|Pre-existing secrets to mount within the container. |
 |[extraConfigmapMounts](../../common_docs/EXTRA_EXAMPLES.md#extraConfigmapMounts)|{}|Pre-existing configmaps to mount within the container. |

--- a/helm-chart-sources/logstream-leader/templates/claims.yaml
+++ b/helm-chart-sources/logstream-leader/templates/claims.yaml
@@ -1,14 +1,23 @@
+{{- if .Values.persistence.enabled }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: leader-config-claim
+  name: {{ coalesce .Values.persistence.claimName (include "logstream-leader.fullname" .) }}
+  labels:
+    {{- include "logstream-leader.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations: {{- . | toYaml | nindent 4 }}
+  {{- end }}
 spec:
-  accessModes:
-    - ReadWriteOnce
-  {{- if .Values.config.scName }}
-  storageClassName:   {{ .Values.config.scName }}
+  accessModes: {{ .Values.persistence.accessModes | toYaml | nindent 4 }}
+  {{- with coalesce .Values.persistence.storageClassName .Values.config.scName }}
+  storageClassName: {{ . }}
   {{- end }}
   resources:
     requests:
-      storage: 20Gi
+      storage: {{ .Values.persistence.size | default "20Gi" }}
+{{- with .Values.persistence.extraSpec }}
+  {{- . | toYaml | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/helm-chart-sources/logstream-leader/tests/claims_test.yaml
+++ b/helm-chart-sources/logstream-leader/tests/claims_test.yaml
@@ -1,0 +1,162 @@
+suite: Persistent Volume Claims
+templates:
+  - claims.yaml
+  - deployment.yaml
+tests:
+  - it: Should have a claim by default
+    template: claims.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PersistentVolumeClaim
+
+  - it: Uses the legacy claim name
+    template: claims.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: leader-config-claim
+
+  - it: Uses the dynamic claim name
+    template: claims.yaml
+    release:
+      name: cribl-leader-goat
+    set:
+      persistence:
+        claimName:
+    asserts:
+      - notEqual:
+          path: metadata.name
+          value: leader-config-claim
+      - equal:
+          path: metadata.name
+          value: cribl-leader-goat
+
+  - it: Uses the dynamic claim name
+    template: deployment.yaml
+    set:
+      persistence:
+        claimName:
+    release:
+      name: cribl-leader-goat
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == 'config-storage')].persistentVolumeClaim.claimName
+          value: cribl-leader-goat
+
+  - it: Sets the annotations
+    template: claims.yaml
+    set:
+      persistence:
+        annotations:
+          foo: bar
+          goat: 🐐
+    asserts:
+      - exists:
+          path: metadata.annotations
+      - equal:
+          path: metadata.annotations
+          value:
+            foo: bar
+            goat: 🐐
+
+  - it: Sets the accessModes array
+    template: claims.yaml
+    set:
+      persistence:
+        accessModes:
+          - foo
+          - bar
+          - baz
+    asserts:
+      - equal:
+          path: spec.accessModes
+          value:
+            - foo
+            - bar
+            - baz
+
+  - it: Sets the storage size
+    template: claims.yaml
+    set:
+      persistence:
+        size: 100Gi
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: 100Gi
+
+  - it: Should disable the claim
+    template: claims.yaml
+    set:
+      persistence:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Uses an empty dir when claim disabled
+    template: deployment.yaml
+    set:
+      persistence:
+        enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == 'config-storage')]
+          value:
+            name: config-storage
+            emptyDir: {}
+
+  - it: Should coalesce the storageClassName setting (1)
+    template: claims.yaml
+    set:
+      persistence:
+        storageClassName: foo
+      config:
+        scName: bar
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: foo
+
+  - it: Should coalesce the storageClassName setting (2)
+    template: claims.yaml
+    set:
+      config:
+        scName: bar
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: bar
+
+  - it: Should not set the storageClassName setting
+    template: claims.yaml
+    asserts:
+      - notExists:
+          path: spec.storageClassName
+
+  - it: Should add extra spec
+    template: claims.yaml
+    set:
+      persistence:
+        extraSpec:
+          foo: bar
+          goat:
+            - 1
+            - 2
+            - 3
+    asserts:
+      - exists:
+          path: spec.foo
+      - equal:
+          path: spec.foo
+          value: bar
+      - exists:
+          path: spec.goat
+      - equal:
+          path: spec.goat
+          value:
+            - 1
+            - 2
+            - 3

--- a/helm-chart-sources/logstream-leader/tests/fixtures/persistence.yaml
+++ b/helm-chart-sources/logstream-leader/tests/fixtures/persistence.yaml
@@ -1,0 +1,10 @@
+persistence:
+  claimName: goat-powered
+  storageClassName: goatspeed
+  accessModes:
+    - ReadWriteMany
+  size: 30Gi
+  annotations:
+    cribl.io/name: goaty
+  extraSpec:
+    volumeName: super-goat

--- a/helm-chart-sources/logstream-leader/tests/fixtures/persistence_disabled.yaml
+++ b/helm-chart-sources/logstream-leader/tests/fixtures/persistence_disabled.yaml
@@ -1,0 +1,2 @@
+persistence:
+  enabled: false

--- a/helm-chart-sources/logstream-leader/values.yaml
+++ b/helm-chart-sources/logstream-leader/values.yaml
@@ -48,6 +48,25 @@ config:
 
 env: {}
 
+persistence:
+  # -- Disable this to use an emptyDir for CRIBL_VOLUME_DIR config storage
+  enabled: true
+  # -- Unset claimName to use the Helm Release name as the PVC name
+  # This is set for backwards compatability purposes
+  claimName: leader-config-claim
+  # -- Set storageClassName to use a class other than the default
+  # Will prioritize this value above the value defined in config.scName
+  storageClassName:
+  # -- Access Modes for the Cribl Leader configs
+  accessModes:
+    - ReadWriteOnce
+  # -- The size of the requested persistent volume claim
+  size: 20Gi
+  # -- Define any annotation KVs to be set on the PVC
+  annotations: {}
+  # -- extraSpec permits any custom spec values to be added to the PVC config
+  extraSpec: {}
+
 service:
   internalType: ClusterIP
   externalType: LoadBalancer


### PR DESCRIPTION
This PR updates the `claims.yaml` file for the `logstream-leader` chart.

The following capabilities have been added:
- Disabling persistence by setting`persistence.enabled=false` so that the Leader Pod uses an `emptyDir` instead of a PVC.
- Allowing a custom claimName to be set. Setting the value to null (i.e. `--set="persistence.claimName="`) results in the Helm Release name being used for the PVC resource. By default the `claimName` value is set to `leader-config-claim` for backwards compatibility purposes.
- Allows for custom annotations and other PVC spec values to be set.

Resolves #196 