### PR TITLE
Updated the pod template environment variables.

### DIFF
--- a/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
+++ b/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
@@ -63,8 +63,8 @@ containers:
       {{ toYaml .Values.envValueFrom | nindent 6  }}
       {{- end }}
       {{- range $key, $value := .Values.env }}
-      - name: {{ $key }}"
-        value: {{ $value }}
+      - name: {{ $key }}
+        value: {{ $value | quote }}
       {{- end }}
 
     volumeMounts:

--- a/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
+++ b/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
@@ -63,8 +63,8 @@ containers:
       {{ toYaml .Values.envValueFrom | nindent 6  }}
       {{- end }}
       {{- range $key, $value := .Values.env }}
-      - name: "{{ tpl $key $ }}"
-        value: "{{ tpl (print $value) $ }}"
+      - name: {{ $key }}"
+        value: {{ $value }}
       {{- end }}
 
     volumeMounts:


### PR DESCRIPTION
The way the environment variables were being set using the 'tpl' function didn't work when setting CRIBL_BOOTSTRAP to override config files. 