### PR TITLE
Bump GitHub Actions dependencies & fix typos

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,15 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: 3.12.3
+        uses: azure/setup-helm@v4.2.0
 
       - name: Install unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.3.5
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.5.2
 
       - name: helm lint
         run: helm lint helm-chart-sources/*
@@ -23,12 +21,12 @@ jobs:
       - name: helm unittest
         run: helm unittest helm-chart-sources/*
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '>=1.19.0'
 
       - name: Install kubeconform
-        run: go install github.com/yannh/kubeconform/cmd/kubeconform@v0.6.3
+        run: go install github.com/yannh/kubeconform/cmd/kubeconform@v0.6.7
 
       - name: kubeconform
         run: ./scripts/kubeconform.sh

--- a/common_docs/EXTRA_EXAMPLES.md
+++ b/common_docs/EXTRA_EXAMPLES.md
@@ -124,12 +124,12 @@ If you specify a `extraVolumeMounts.claimTemplate` attribute (and you have speci
 <dt>readOnly</dt>
 <dd>Whether to mount the volume read-only or read/write – default is read/write. </dd>
 <dt>claimTemplate</dt>
-<dd>If this is set, it decribes the PVC that will be created for each pod. <em>Statefulset deployment only.</em></dd>
+<dd>If this is set, it describes the PVC that will be created for each pod. <em>Statefulset deployment only.</em></dd>
 </dl>
 
 ### Example
 This example mounts two extra directories:
-* An `emptyDir`, mounted on /var/lib/testin
+* An `emptyDir`, mounted on /var/lib/testing
 * An existing PVC, called `test-volume`, mounted on `/var/tmp/test-volume`
 
 ```

--- a/helm-chart-sources/logstream-leader/values.yaml
+++ b/helm-chart-sources/logstream-leader/values.yaml
@@ -53,7 +53,7 @@ persistence:
   # -- Disable this to use an emptyDir for CRIBL_VOLUME_DIR config storage
   enabled: true
   # -- Unset claimName to use the Helm Release name as the PVC name
-  # This is set for backwards compatability purposes
+  # This is set for backwards compatibility purposes
   claimName: leader-config-claim
   # -- Set storageClassName to use a class other than the default
   # Will prioritize this value above the value defined in config.scName


### PR DESCRIPTION
List of changes:

- Update dependencies on GitHub PR action workflow:
To Get rid of the following warning: https://github.com/criblio/helm-charts/actions/runs/10150459917
<img width="1672" alt="image" src="https://github.com/user-attachments/assets/36eac3a6-46a4-42c7-a474-9b2e88adf1ad">


Fix typos
- `compatability` > `compatibility`
- `decribes` > `describes`
- `testin` > `testing`
