### PR TITLE
Allow terminationGracePeriodSeconds to be configured

### DIFF
--- a/helm-chart-sources/edge/templates/daemonset.yaml
+++ b/helm-chart-sources/edge/templates/daemonset.yaml
@@ -162,6 +162,9 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }
       {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-chart-sources/edge/templates/daemonset.yaml
+++ b/helm-chart-sources/edge/templates/daemonset.yaml
@@ -164,7 +164,7 @@ spec:
       {{- end }}
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      {{- end }
+      {{- end }}
       {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-chart-sources/edge/values.yaml
+++ b/helm-chart-sources/edge/values.yaml
@@ -285,3 +285,7 @@ extraObjects: {}
 extraLabels: {}
 # key: value
 # key2: value2
+
+# Pods get 30s by default for orderly shutdown before they're killed but may
+# need a little more time in various scenarios. Set this to allow more time.
+# terminationGracePeriodSeconds: 60s

--- a/helm-chart-sources/logstream-leader/templates/_pod.tpl
+++ b/helm-chart-sources/logstream-leader/templates/_pod.tpl
@@ -226,4 +226,7 @@ affinity:
 tolerations:
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- if .Values.terminationGracePeriodSeconds }}
+terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+{{- end }}
 {{- end }}

--- a/helm-chart-sources/logstream-leader/values.yaml
+++ b/helm-chart-sources/logstream-leader/values.yaml
@@ -132,3 +132,7 @@ extraObjects: {}
 extraLabels: {}
 # key: value
 # key2: value2
+
+# Pods get 30s by default for orderly shutdown before they're killed but may
+# need a little more time in various scenarios. Set this to allow more time.
+# terminationGracePeriodSeconds: 60s

--- a/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
+++ b/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
@@ -150,4 +150,8 @@ volumes:
   {{- end }}
   {{- end }}
 
+{{- if .Values.terminationGracePeriodSeconds }}
+terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+{{- end }}
+
 {{- end }}

--- a/helm-chart-sources/logstream-workergroup/values.yaml
+++ b/helm-chart-sources/logstream-workergroup/values.yaml
@@ -216,3 +216,7 @@ extraVolumeMounts: {}
 #       resources:
 #         requests:
 #           storage: 1Gi
+
+# Pods get 30s by default for orderly shutdown before they're killed but may
+# need a little more time in various scenarios. Set this to allow more time.
+# terminationGracePeriodSeconds: 60s


### PR DESCRIPTION
We're adjusting the `cribl/cribl` image's `entrypoint.sh` to gracefully shutdown and in some scenarios, the default 30s timer may need to be extended.  This adjusts the Helm charts so `terminationGracePeriodSeconds` can be set in the `values.yaml` files. 