### PR TITLE
Adjust workergroup resource limits

### DIFF
--- a/helm-chart-sources/logstream-workergroup/values.yaml
+++ b/helm-chart-sources/logstream-workergroup/values.yaml
@@ -116,9 +116,18 @@ service:
 
 resources: 
   limits:
-    cpu: 2000m
-    memory: 4096Mi
+    # The stock limits below result in Stream running 4 worker processes in the
+    # pod with 2 additional cores available for the server process and for threads
+    # handling I/O, compression, etc. Prior to the 4.11.0 release, these limits
+    # were 2000m and 4192Mi which was likely to cause degraded throughput at
+    # realistic loads.
+    cpu: 6000m
+    memory: 8192Mi
   requests:
+    # Note that these request levels are extremely low for a production
+    # deployment but changing the stock settings could break existing users
+    # so we've not adjusted them. Setting them closer to the limits above is
+    # recommended to avoid starving the pods on oversubscribed cluster nodes.
     cpu: 1250m
     memory: 256Mi
 


### PR DESCRIPTION
Intent is to have the OOB experience work better. The previous PR adds the envvar to expose the CPU limit to the pod. The upcoming 4.11.0 release of Stream will honor this limit instead of using the host's CPU count. As a result, the stock Stream pods will be running 2 worker processes, 1 server process, and be limited to 2 CPUs which doesn't yield the expected throughput if the product.  

This PR adjusts the CPU and memory limits so we end up with 4 worker processes and 1 server process and a limit of 6 CPUs.  The server and workers should not be throttled by the cluster in this setup and should have room for workers to consume more that 100% of a core occasionally which happens when we offload compression and I/O handling. 

Users can override the defaults still of course to increase the workers by adjusting the CPU limit. They can reduce the padding by configuring their Worker Group to use `-1` instead of `-2` for the worker process count. They can override the automatic worker count logic by setting the count directly. They still have control. This just changes the defaults so new users have a better experience.