### PR TITLE
fix(helm): resolve shared annotation references in helm templates

### DIFF
--- a/helm-chart-sources/logstream-leader/templates/service-internal.yaml
+++ b/helm-chart-sources/logstream-leader/templates/service-internal.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "logstream-leader.labels" . | nindent 4 }}
   annotations:
-    {{- include "logstream-leader.service.annotations" (merge (dict "templateType" "internal") .) | nindent 4 }}
+    {{- include "logstream-leader.service.annotations" (merge (dict "templateType" "internal") (deepCopy .)) | nindent 4 }}
 spec:
   type: {{ .Values.service.internalType }}
   ports:

--- a/helm-chart-sources/logstream-leader/templates/service.yaml
+++ b/helm-chart-sources/logstream-leader/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "logstream-leader.labels" . | nindent 4 }}
   annotations:
-    {{- include "logstream-leader.service.annotations" (merge (dict "templateType" "external") .) | nindent 4 }}
+    {{- include "logstream-leader.service.annotations" (merge (dict "templateType" "external") (deepCopy .)) | nindent 4 }}
 spec:
   type: {{- if (eq $.Values.ingress.enable true) }} NodePort {{- else }} {{ .Values.service.externalType }} {{- end }}
   ports:


### PR DESCRIPTION
## PR Description: Resolve shared annotation references in helm templates

### Problem
Our Helm charts were experiencing issues with annotation handling, particularly when merging shared and service-specific annotations. This led to unexpected behavior where annotations intended for one service type (internal or external) were appearing on both.

### Reproduce
Add an external annotation to the `values.yaml` and `helm template .`. Both internal services and external services receive a merge within their annotations.

#### Input
```yaml
service:
  internalType: ClusterIP
  externalType: LoadBalancer
  # annotations are shared between both the internal and external Service
  annotations: {}
  # internalAnnotations are only applied to the internal Service
  internalAnnotations: {}
  # externalAnnotations are only applied to the external Service
  externalAnnotations:
    foo: bar
```

#### Output
```yaml
---
# Source: logstream-leader/templates/service-internal.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-leader-internal
  labels:
    helm.sh/chart: logstream-leader-4.10.1
    app.kubernetes.io/name: leader
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "4.10.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    foo: bar
spec:
  type: ClusterIP
  ports:
      - port: 9000
        targetPort: 9000
        protocol: TCP
        name: api
        
      - port: 4200
        targetPort: 4200
        protocol: TCP
        name: leadercomm
        
  selector:
    app.kubernetes.io/name: leader
    app.kubernetes.io/instance: release-name
---
# Source: logstream-leader/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-leader
  labels:
    helm.sh/chart: logstream-leader-4.10.1
    app.kubernetes.io/name: leader
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "4.10.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    foo: bar
spec:
  type: LoadBalancer
  ports:
      - port: 9000
        targetPort: 9000
        protocol: TCP
        name: api
        
  selector:
    app.kubernetes.io/name: leader
    app.kubernetes.io/instance: release-name
```

