### PR TITLE
Added ability to define affinity for pods

### DIFF
--- a/helm-chart-sources/logstream-workergroup/README.md
+++ b/helm-chart-sources/logstream-workergroup/README.md
@@ -63,7 +63,7 @@ This section covers the most likely values to override. To see the full scope of
 |serviceAccount.create|true|Create a ServiceAccount used by the Pods.|
 |serviceAccount.name|`undefined`|The ServiceAccount name. If `serviceAccount.create` is true, the ServiceAccount is named this value. If false, the ServiceAccount must already exist.|
 |nodeSelector|{}|Add nodeSelector values to define which nodes the pods are scheduled on - see [k8s Documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) for details and allowed values. |
-|affinity|{}|Add affinity values to define constrain which nodes the pods are scheduled on - see [k8s Documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for details and allowed values. |
+|affinity|{}|Add affinity values to define constraints which nodes the pods are scheduled on - see [k8s Documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for details and allowed values. |
 |__Extra Configuration Options__|
 |strategy|see `values.yaml`|Add strategy values to define how Pods are upgraded - see k8s Documentation [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) and [DaemonSet](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/) for details and allowed values.|
 |__Extra Configuration Options__|

--- a/helm-chart-sources/logstream-workergroup/README.md
+++ b/helm-chart-sources/logstream-workergroup/README.md
@@ -63,6 +63,8 @@ This section covers the most likely values to override. To see the full scope of
 |serviceAccount.create|true|Create a ServiceAccount used by the Pods.|
 |serviceAccount.name|`undefined`|The ServiceAccount name. If `serviceAccount.create` is true, the ServiceAccount is named this value. If false, the ServiceAccount must already exist.|
 |nodeSelector|{}|Add nodeSelector values to define which nodes the pods are scheduled on - see [k8s Documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) for details and allowed values. |
+|affinity|{}|Add affinity values to define constrain which nodes the pods are scheduled on - see [k8s Documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for details and allowed values. |
+|__Extra Configuration Options__|
 |strategy|see `values.yaml`|Add strategy values to define how Pods are upgraded - see k8s Documentation [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) and [DaemonSet](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/) for details and allowed values.|
 |__Extra Configuration Options__|
 |[extraVolumeMounts](../../common_docs/EXTRA_EXAMPLES.md#extraVolumeMounts)|{}|Additional Volumes to mount in the container.|

--- a/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
+++ b/helm-chart-sources/logstream-workergroup/templates/_pod.tpl
@@ -109,6 +109,11 @@ nodeSelector:
   {{- toYaml .  | nindent 2 }}
 {{- end }}
 
+{{- with .Values.affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+
 {{- with .Values.tolerations }}
 tolerations:
   {{- toYaml . | nindent 2 }}


### PR DESCRIPTION
## Problem

User want to constrain the Pods to prefer or restrict particular nodes in a cluster.  nodeSelector is the simplest way to constrain Pods to nodes with specific labels. Affinity and anti-affinity expands the types of constraints you can define. 

## Solution

This PR includes the option to add affinity to the worker group pods, similar to the leader chart. This fixes #207.

## Work 

- Added the ability to define affinity for worker group pods, based on the template of the leader chart.
- Added Readme entry.
