### PR TITLE
Adds persistentVolumeClaimRetentionPolicy to the statefulset.yaml

### DIFF
--- a/common_docs/EXTRA_EXAMPLES.md
+++ b/common_docs/EXTRA_EXAMPLES.md
@@ -277,3 +277,18 @@ This example provides access to `deployments`, allowing verbs `get`, `list`, `wa
   resources: ["deployments"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ```
+
+## Using statefulset.persistentVolumeClaimRetentionPolicy <a name="statefulset.persistentVolumeClaimRetentionPolicy"></a>
+_Availability: logstream-workergroup_
+
+Use `statefulset.persistentVolumeClaimRetentionPolicy` to specify how the cluster should handle volumes when a stateful set scales down or is deleted. `Retain` is the default option. The documentation for this feature is available on this [K8s Doc Page](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)
+
+### Example
+This example will delete PVCs when the StatefulSet is scaled or deleted.
+
+```
+statefulset:
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete 
+    whenScaled: Delete
+```

--- a/helm-chart-sources/logstream-workergroup/templates/statefulset.yaml
+++ b/helm-chart-sources/logstream-workergroup/templates/statefulset.yaml
@@ -11,6 +11,10 @@ spec:
   selector:
     matchLabels:
       {{- include "logstream-workergroup.selectorLabels" . | nindent 6 }}
+  {{- with .Values.statefulset.persistentVolumeClaimRetentionPolicy}}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if (.Values.strategy) }}
   {{- if and (ne .Values.strategy.type "OnDelete") (ne .Values.strategy.type "RollingUpdate") }}
       {{- fail (printf "Not a valid strategy type for StatefulSet (%s)" .Values.strategy.type) }}
@@ -39,3 +43,4 @@ spec:
     - {{ .claimTemplate | toYaml | indent 6 | trim }}
     {{- end }}
 {{- end }}
+

--- a/helm-chart-sources/logstream-workergroup/values.yaml
+++ b/helm-chart-sources/logstream-workergroup/values.yaml
@@ -58,6 +58,11 @@ config:
 
 deployment: deployment
 
+statefulset:
+  persistentVolumeClaimRetentionPolicy: {}
+    # whenDeleted: Delete 
+    # whenScaled: Delete
+
 podAnnotations: {}
 
 # Add an annotation to the deployment pods that will automatically restart the


### PR DESCRIPTION
Adds persistentVolumeClaimRetentionPolicy to the statefulset.yaml to allow consumers of the template the ability to decide how PVs are handled when a stateful set scales down or is deleted. Currently when pods scale down or the stateful set is deleted the PVs are orphaned. This change allows teams to decide if the PV should be automatically removed with the pod or retained due to some retention policy at their org. 