### PR TITLE
Add Outpost chart to `bump-version` script

### DIFF
--- a/helm-chart-sources/outpost/Chart.yaml
+++ b/helm-chart-sources/outpost/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.14.1
+version: 4.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.14.1
+appVersion: 4.15.0

--- a/helm-chart-sources/outpost/values.yaml
+++ b/helm-chart-sources/outpost/values.yaml
@@ -40,7 +40,7 @@ criblImage:
   repository: cribl/cribl
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 4.14.1
+  tag: 4.15.0
   wolfiImage: false
 
 imagePullSecrets: []

--- a/scripts/bump-version
+++ b/scripts/bump-version
@@ -15,10 +15,10 @@ fi
 echo Bumping helm-charts default Cribl version to $tag
 git stash
 
-perl -i -pe "s/^(?:appVersion|version): \K[\d\.]+/$tag/" helm-chart-sources/{logstream-{leader,workergroup},edge}/Chart.yaml
-perl -i -pe "s/^\s+tag: \K[\d\.]+/$tag/" helm-chart-sources/{logstream-{leader,workergroup},edge}/values.yaml
-perl -i -pe "s/Support for the \K[\d\.]+/$tag/" helm-chart-sources/{logstream-{leader,workergroup},edge}/README.md
-perl -i -pe "s/^\W image.tag\W+\K[\d\.]+/$tag/" helm-chart-sources/{logstream-{leader,workergroup},edge}/README.md
+perl -i -pe "s/^(?:appVersion|version): \K[\d\.]+/$tag/" helm-chart-sources/{logstream-{leader,workergroup},edge,outpost}/Chart.yaml
+perl -i -pe "s/^\s+tag: \K[\d\.]+/$tag/" helm-chart-sources/{logstream-{leader,workergroup},edge,outpost}/values.yaml
+perl -i -pe "s/Support for the \K[\d\.]+/$tag/" helm-chart-sources/{logstream-{leader,workergroup},edge,outpost}/README.md
+perl -i -pe "s/^\W image.tag\W+\K[\d\.]+/$tag/" helm-chart-sources/{logstream-{leader,workergroup},edge,outpost}/README.md
 
 git commit -am "Bump version to $tag"
 git tag -am "Released version $tag" v$tag


### PR DESCRIPTION
* Added outpost to the script we run to bump versions when we release Cribl versions.
* Adjusted the current versions for Cribl Outpost that didn't get bumped by the script this morning.