### PR TITLE
feat(edge): Add affinity support to DaemonSet

### DIFF
--- a/helm-chart-sources/edge/README.md
+++ b/helm-chart-sources/edge/README.md
@@ -79,5 +79,6 @@ This section covers the most likely values to override. To see the full scope of
 | resources.limits                                                               | see `values.yaml` | Limits for the Edge Pod                                                             |
 | resources.requests                                                             | see `values.yaml` | Reserved resources for the Edge Pod                                                 |
 | nodeSelector                                                                   | `{}`              | Node selection for Pod deployment                                                   |
+| affinity                                                                       | `{}`              | Pod affinity/anti-affinity rules for scheduling                                     |
 | tolerations                                                                    | see `values.yaml` | Node tolerations/taints allowed for deploying the Edge Pods                         |
 | extraObjects                                                                   | `{}`              | Ability to add custom Kubernetes objects into this deployment as part of this chart |

--- a/helm-chart-sources/edge/templates/daemonset.yaml
+++ b/helm-chart-sources/edge/templates/daemonset.yaml
@@ -43,6 +43,9 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if or .Values.extraVolumeMounts .Values.extraConfigmapMounts .Values.extraSecretMounts }}
       volumes:
         {{- range .Values.extraVolumeMounts }}

--- a/helm-chart-sources/edge/tests/daemonset_test.yaml
+++ b/helm-chart-sources/edge/tests/daemonset_test.yaml
@@ -200,3 +200,34 @@ tests:
             - key: "goat"
               operator: "Exists"
               effect: "NoSchedule"
+
+  - it: Should correctly set the affinity
+    set:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: eks.amazonaws.com/compute-type
+                    operator: NotIn
+                    values:
+                      - fargate
+    asserts:
+      - exists:
+          path: spec.template.spec.affinity
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: eks.amazonaws.com/compute-type
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator
+          value: NotIn
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+          value: fargate
+
+  - it: Should not set affinity when empty
+    set:
+      affinity: {}
+    asserts:
+      - notExists:
+          path: spec.template.spec.affinity

--- a/helm-chart-sources/edge/values.yaml
+++ b/helm-chart-sources/edge/values.yaml
@@ -281,6 +281,8 @@ resources:
 
 nodeSelector: {}
 
+affinity: {}
+
 # By default, allow scheduling DaemonSet on any Node in the Cluster
 tolerations:
   - operator: Exists


### PR DESCRIPTION
## Summary
Adds support for `affinity` configuration in the Edge helm chart, bringing it in line with the logstream-workergroup chart.

Fixes #241

## Changes
- Added `affinity: {}` to `values.yaml`
- Added affinity template block to `daemonset.yaml`
- Added tests for affinity configuration
- Documented affinity in `README.md`

## Usage Example
```yaml
affinity:
  nodeAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      nodeSelectorTerms:
        - matchExpressions:
            - key: eks.amazonaws.com/compute-type
              operator: NotIn
              values:
                - fargate
```

## Testing
- `helm template` renders affinity correctly when provided
- Affinity block is omitted when empty (default behavior)
- Follows existing patterns for `nodeSelector` and `tolerations`