### PR TITLE
Update deployment.yaml, values.yml to hard code replicas

### DIFF
--- a/helm-chart-sources/logstream-leader/templates/deployment.yaml
+++ b/helm-chart-sources/logstream-leader/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "logstream-leader.labels" . | nindent 4 }}
 spec:
 {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
 {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
leader HA is a bit more complicated than replicas=2 and setting this to 2+ without the other HA setup done will cause bad things

should probably keep replicas out of values.yml until our helm chart has more support for HA
