### PR TITLE
feat(edge): Add RBAC rules for monitoring.coreos.com ServiceMonitors

### DIFF
--- a/helm-chart-sources/edge/tests/rbac_test.yaml
+++ b/helm-chart-sources/edge/tests/rbac_test.yaml
@@ -83,6 +83,19 @@ tests:
       - isAPIVersion:
           of: rbac.authorization.k8s.io/v1
 
+  - it: Defines ClusterRole Rules for ServiceMonitors
+    template: rbac/clusterrole.yaml
+    asserts:
+      - contains:
+          path: rules
+          any: true
+          content:
+            apiGroups:
+              - "monitoring.coreos.com"
+            resources:
+              - servicemonitors
+            verbs: ['get', 'list', 'watch']
+
   - it: Correctly includes extraRules
     template: rbac/clusterrole.yaml
     set:

--- a/helm-chart-sources/edge/values.yaml
+++ b/helm-chart-sources/edge/values.yaml
@@ -120,6 +120,7 @@ rbac:
     - apiGroups:
         - ""
       resources:
+        - endpoints
         - namespaces
         - nodes
         - nodes/log
@@ -129,17 +130,16 @@ rbac:
         - nodes/stats
         - pods
         - pods/log
+        - services
       verbs: ['get', 'list', 'watch']
     - apiGroups:
         - ""
       resources:
         - configmaps
-        - endpoints
         - limitranges
         - persistentvolumeclaims
         - replicationcontrollers
         - secrets
-        - services
         - strategicMergePatches
       verbs: ['list', 'watch']
     - apiGroups:
@@ -200,6 +200,11 @@ rbac:
         - namespaces
         - resourcequotas
       verbs: ['get', 'list']
+    - apiGroups:
+        - "monitoring.coreos.com"
+      resources:
+        - servicemonitors
+      verbs: ['get', 'list', 'watch']
   extraRules: []
   # - apiGroups: []
   #   resources: []


### PR DESCRIPTION
RBAC additions to support upcoming support in Cribl Edge for a new K8S ServiceMonitor discovery mode in the EdgePrometheus Scraper source. (CRIBL-29545)

- Add RBAC ClusterRole rule granting `get`, `list`, `watch` access to `monitoring.coreos.com` `servicemonitors` resources, enabling Edge to access the ServiceMonitors API                                                                                                                                  
- Promote `endpoints` and `services` from `list`/`watch` to `get`/`list`/`watch` permissions by moving them into the existing core API resource block
- Add unit test verifying the new ServiceMonitors ClusterRole rule